### PR TITLE
Don't dllexport when building static

### DIFF
--- a/cmake/SQLite/CMakeLists.txt
+++ b/cmake/SQLite/CMakeLists.txt
@@ -5,7 +5,7 @@ project(SQLite LANGUAGES C)
 
 add_library(SQLite3
   sqlite3.c)
-if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+if(CMAKE_SYSTEM_NAME STREQUAL Windows AND BUILD_SHARED_LIBS)
   target_compile_definitions(SQLite3 PRIVATE
     "SQLITE_API=__declspec(dllexport)")
 endif()


### PR DESCRIPTION
We only want to dllexport when building shared, else executables that
link against the static library will reexport the exports.