### PR TITLE
SDK: attempt to force the android SDK Swift compiler

### DIFF
--- a/.ci/templates/android-sdk.yml
+++ b/.ci/templates/android-sdk.yml
@@ -114,7 +114,7 @@ jobs:
       - task: CMake@1
         inputs:
           workingDirectory: $(Build.StagingDirectory)/libdispatch
-          cmakeArgs: -C $(Build.SourcesDirectory)/cmake/caches/android-${{ parameters.arch }}.cmake -DSWIFT_ANDROID_SDK=$(Build.StagingDirectory)/Library/Developer/Platforms/Android.platform/Developer/SDKs/Android.sdk -C $(Build.SourcesDirectory)/cmake/caches/android-${{ parameters.arch }}-swift-flags.cmake -G Ninja $(Build.SourcesDirectory)/swift-corelibs-libdispatch -DANDROID_ALTERNATE_TOOLCHAIN=$(toolchain.directory)/usr -DCMAKE_TOOLCHAIN_FILE=$(Build.SourcesDirectory)/cmake/toolchains/android.toolchain.cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SWIFT_COMPILER=swiftc -DCMAKE_INSTALL_PREFIX=$(install.directory) -DENABLE_TESTING=NO -DENABLE_SWIFT=YES
+          cmakeArgs: -C $(Build.SourcesDirectory)/cmake/caches/android-${{ parameters.arch }}.cmake -DSWIFT_ANDROID_SDK=$(Build.StagingDirectory)/Library/Developer/Platforms/Android.platform/Developer/SDKs/Android.sdk -C $(Build.SourcesDirectory)/cmake/caches/android-${{ parameters.arch }}-swift-flags.cmake -G Ninja $(Build.SourcesDirectory)/swift-corelibs-libdispatch -DANDROID_ALTERNATE_TOOLCHAIN=$(toolchain.directory)/usr -DCMAKE_TOOLCHAIN_FILE=$(Build.SourcesDirectory)/cmake/toolchains/android.toolchain.cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SWIFT_COMPILER=swiftc -DCMAKE_INSTALL_PREFIX=$(install.directory) -DENABLE_TESTING=NO -DENABLE_SWIFT=YES -DCMAKE_Swift_COMPILER_WORKS=YES
         displayName: 'Configure libdispatch'
       - task: CMake@1
         inputs:


### PR DESCRIPTION
CMake's cross-compilation detection is currently not setup for testing
with the explicit target.  We need to force the compiler until that is
fixed.