### PR TITLE
android: workaround CMake bug

### DIFF
--- a/cmake/caches/android-aarch64-swift-flags.cmake
+++ b/cmake/caches/android-aarch64-swift-flags.cmake
@@ -12,6 +12,9 @@ set(CMAKE_SWIFT_LINK_FLAGS
       -Xclang-linker -fuse-ld=gold.exe
     CACHE STRING "")
 
+if(CMAKE_VERSION VERSION_LESS 3.16)
+  list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES CMAKE_Swift_COMPILER_TARGET)
+endif()
 set(CMAKE_Swift_COMPILER_TARGET aarch64-unknown-linux-android CACHE STRING "")
 set(CMAKE_Swift_FLAGS "-resource-dir ${SWIFT_ANDROID_SDK}/usr/lib/swift -Xcc --sysroot=${CMAKE_ANDROID_NDK}/sysroot" CACHE STRING "")
 

--- a/cmake/caches/android-armv7-swift-flags.cmake
+++ b/cmake/caches/android-armv7-swift-flags.cmake
@@ -12,6 +12,9 @@ set(CMAKE_SWIFT_LINK_FLAGS
       -Xclang-linker -fuse-ld=gold.exe
     CACHE STRING "")
 
+if(CMAKE_VERSION VERSION_LESS 3.16)
+  list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES CMAKE_Swift_COMPILER_TARGET)
+endif()
 set(CMAKE_Swift_COMPILER_TARGET armv7-unknown-linux-androideabi CACHE STRING "")
 set(CMAKE_Swift_FLAGS "-resource-dir ${SWIFT_ANDROID_SDK}/usr/lib/swift -Xcc --sysroot=${CMAKE_ANDROID_NDK}/sysroot" CACHE STRING "")
 

--- a/cmake/caches/android-i686-swift-flags.cmake
+++ b/cmake/caches/android-i686-swift-flags.cmake
@@ -12,6 +12,9 @@ set(CMAKE_SWIFT_LINK_FLAGS
       -Xclang-linker -fuse-ld=gold.exe
     CACHE STRING "")
 
+if(CMAKE_VERSION VERSION_LESS 3.16)
+  list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES CMAKE_Swift_COMPILER_TARGET)
+endif()
 set(CMAKE_Swift_COMPILER_TARGET i686-unknown-linux-android CACHE STRING "")
 set(CMAKE_Swift_FLAGS "-resource-dir ${SWIFT_ANDROID_SDK}/usr/lib/swift -Xcc --sysroot=${CMAKE_ANDROID_NDK}/sysroot" CACHE STRING "")
 

--- a/cmake/caches/android-x86_64-swift-flags.cmake
+++ b/cmake/caches/android-x86_64-swift-flags.cmake
@@ -12,6 +12,9 @@ set(CMAKE_SWIFT_LINK_FLAGS
       -Xclang-linker -fuse-ld=gold.exe
     CACHE STRING "")
 
+if(CMAKE_VERSION VERSION_LESS 3.16)
+  list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES CMAKE_Swift_COMPILER_TARGET)
+endif()
 set(CMAKE_Swift_COMPILER_TARGET x86_64-unknown-linux-android CACHE STRING "")
 set(CMAKE_Swift_FLAGS "-resource-dir ${SWIFT_ANDROID_SDK}/usr/lib/swift -Xcc --sysroot=${CMAKE_ANDROID_NDK}/sysroot" CACHE STRING "")
 


### PR DESCRIPTION
Ensure that we push `CMAKE_Swift_COMPILER_TARGET` to the sub-configure.
This has been fixed in CMake, but provide compatibility for older CMake
versions.