### PR TITLE
Update the WinSDK build

### DIFF
--- a/utilities/Download-SwiftArtifacts.ps1
+++ b/utilities/Download-SwiftArtifacts.ps1
@@ -59,7 +59,7 @@ function Download-Build([Int] $BuildID, [String] $ArtifactName) {
     if ($Arch -ne "x64") {
       return "[WARNING] The windows sdk currently only supports x64, skipping download for $Arch"
     }
-    $LatestArtifacts = Invoke-RestMethod -Uri "https://dev.azure.com/compnerd/windows-swift/_apis/build/builds/9704/artifacts?api-version-string=5.0"
+    $LatestArtifacts = Invoke-RestMethod -Uri "https://dev.azure.com/compnerd/windows-swift/_apis/build/builds/13369/artifacts?api-version-string=5.0"
   } else {
     $LatestBuild = Invoke-RestMethod -Uri "https://dev.azure.com/compnerd/windows-swift/_apis/build/builds?definitions=$BuildID&resultFilter=succeeded,partiallySucceeded&`$top=1&api-version-string=5.0"
     $LatestBuildID = $LatestBuild.value.id


### PR DESCRIPTION
The WinSDK build is hard coded to a specific build where Windows x64
succeeded :(. Since the previous build has been removed, this updates to
one still exists.