### PR TITLE
Pass the Python executable found by UsePythonVersion to CMake.

### DIFF
--- a/.ci/toolchain-vs2017-amd64.yml
+++ b/.ci/toolchain-vs2017-amd64.yml
@@ -42,7 +42,7 @@ jobs:
       icu.version : 64
       icu.directory: $(System.ArtifactsDirectory)/icu-$(platform)-$(host)/ICU-$(icu.version)
 
-      llvm.extra_cmake_flags: -DLLVM_PARALLEL_LINK_JOBS=2
+      llvm.extra_cmake_flags: -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(pythonTools.pythonLocation)/python.exe
       swift.extra_cmake_flags: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DLLVM_PARALLEL_LINK_JOBS=2 -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
       lldb.extra_cmake_flags: -DLLDB_DISABLE_PYTHON=YES
     steps:
@@ -55,6 +55,7 @@ jobs:
       - task: UsePythonVersion@0
         inputs:
           versionSpec: '2.7.x'
+        name: pythonTools
       - script: python -m pip install --upgrade flake8
         displayName: 'Install flake8'
       - script: |


### PR DESCRIPTION
In Windows, CMake FindPythonInterpr uses the registry to find Python if none if provided. Instead of leaving the decision to chance of which Python has written last into the registry, pass the Python found by UsePythonVersion into CMake.

To allow both Unix and Windows, and pipelines that finds an specific Python or not, the template parameter is optional and expands or not into a CMake parameter. This should keep the working pipelines the same, while modifying the failing pipeline to work.