### PR TITLE
toolchain: setup the ability to branch the toolchain **NO_CI**

### DIFF
--- a/.ci/azure-pipelines-aws-agent.yml
+++ b/.ci/azure-pipelines-aws-agent.yml
@@ -20,6 +20,9 @@ jobs:
     # TODO(compnerd) move to Facebook pool
     pool: Default
     variables:
+      core.branch: swift/master
+      branch: master
+
       arch: x86_64
       host: x64
       platform: windows

--- a/.ci/templates/toolchain.yml
+++ b/.ci/templates/toolchain.yml
@@ -3,11 +3,11 @@ steps:
       git config --global user.name 'builder'
       git config --global user.email 'builder@compnerd.org'
 
-      git clone --quiet --depth 1 --single-branch --branch swift/master https://github.com/apple/llvm-project toolchain
+      git clone --quiet --depth 1 --single-branch --branch $(core.branch) https://github.com/apple/llvm-project toolchain
 
-      git clone --quiet --depth 1 --single-branch --branch master https://github.com/apple/swift-cmark toolchain/cmark
-      git clone --quiet --depth 1 --single-branch --branch master https://github.com/apple/swift-corelibs-libdispatch toolchain/swift-corelibs-libdispatch
-      git clone --config core.autocrlf=false --config core.symlinks=true --quiet --depth 1 --single-branch --branch master https://github.com/apple/swift toolchain/swift
+      git clone --quiet --depth 1 --single-branch --branch $(branch) https://github.com/apple/swift-cmark toolchain/cmark
+      git clone --quiet --depth 1 --single-branch --branch $(branch) https://github.com/apple/swift-corelibs-libdispatch toolchain/swift-corelibs-libdispatch
+      git clone --config core.autocrlf=false --config core.symlinks=true --quiet --depth 1 --single-branch --branch $(branch) https://github.com/apple/swift toolchain/swift
     displayName: 'Fetch Sources'
   - task: CMake@1
     inputs:

--- a/.ci/toolchain-darwin-x64.yml
+++ b/.ci/toolchain-darwin-x64.yml
@@ -30,6 +30,9 @@ jobs:
     pool: 
       vmImage: macOS-10.14
     variables:
+      core.branch: swift/master
+      branch: master
+
       arch: x86_64
       host: x64
       platform: darwin

--- a/.ci/toolchain-linux-x64.yml
+++ b/.ci/toolchain-linux-x64.yml
@@ -27,6 +27,9 @@ jobs:
   - job: linux_x64
     pool: FlowKey
     variables:
+      core.branch: swift/master
+      branch: master
+
       arch: x86_64
       host: x64
       platform: linux

--- a/.ci/toolchain-vs2017-amd64.yml
+++ b/.ci/toolchain-vs2017-amd64.yml
@@ -30,6 +30,9 @@ jobs:
     pool:
       vmImage: 'VS2017-Win2016'
     variables:
+      core.branch: swift/master
+      branch: master
+
       arch: x86_64
       host: x64
       platform: windows

--- a/.ci/toolchain-vs2019-amd64.yml
+++ b/.ci/toolchain-vs2019-amd64.yml
@@ -30,6 +30,9 @@ jobs:
     pool:
       vmImage: 'windows-2019'
     variables:
+      core.branch: swift/master
+      branch: master
+
       arch: x86_64
       host: x64
       platform: windows


### PR DESCRIPTION
This introduces a new set of variables (core.branch, controlling the
LLVM tree, and branch controlling the swift branches) to enable reusing
the configuration across different branches.