### PR TITLE
Use FB named pools. Duplicate for VS2019. Use version number in path.

### DIFF
--- a/.ci/toolchain-vs2017-amd64-facebook.yml
+++ b/.ci/toolchain-vs2017-amd64-facebook.yml
@@ -17,8 +17,7 @@ trigger:
 jobs:
   - job: windows_x64
     timeoutInMinutes: 120
-    # TODO(compnerd) move to Facebook pool
-    pool: Default
+    pool: Facebook-VS2017
     variables:
       arch: x86_64
       host: x64
@@ -34,10 +33,12 @@ jobs:
       llvm.extra_cmake_flags: -DLLVM_PARALLEL_LINK_JOBS=2
       swift.extra_cmake_flags: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=8 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
       lldb.extra_cmake_flags: -DLLDB_DISABLE_PYTHON=YES
+
+      visualstudio.version: 2017
     steps:
     - task: BatchScript@1
       inputs:
-        filename: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat
+        filename: C:\Program Files (x86)\Microsoft Visual Studio\$(visualstudio.version)\Community\Common7\Tools\VsDevCmd.bat
         arguments: -no_logo -arch=x64 -host_arch=x64
         modifyEnvironment: true
       displayName: 'vcvarsall.bat'

--- a/.ci/toolchain-vs2019-amd64-facebook.yml
+++ b/.ci/toolchain-vs2019-amd64-facebook.yml
@@ -1,0 +1,79 @@
+pr:
+  branches:
+    include:
+      - master
+  paths:
+    include:
+      - .ci/azure-pipelines-aws-agent.yml
+      - .ci/templates/toolchain.yml
+trigger:
+  branches:
+    include:
+      - master
+  paths:
+    include:
+      - .ci/azure-pipelines-aws-agent.yml
+      - .ci/templates/toolchain.yml
+jobs:
+  - job: windows_x64
+    timeoutInMinutes: 120
+    pool: Facebook-VS2019
+    variables:
+      arch: x86_64
+      host: x64
+      platform: windows
+
+      triple: x86_64-unknown-windows-msvc
+
+      install.directory: $(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
+
+      icu.version : 64
+      icu.directory: $(System.ArtifactsDirectory)/icu-$(platform)-$(host)/ICU-$(icu.version)
+
+      llvm.extra_cmake_flags: -DLLVM_PARALLEL_LINK_JOBS=2
+      swift.extra_cmake_flags: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=8 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
+      lldb.extra_cmake_flags: -DLLDB_DISABLE_PYTHON=YES
+
+      visualstudio.version: 2019
+    steps:
+    - task: BatchScript@1
+      inputs:
+        filename: C:\Program Files (x86)\Microsoft Visual Studio\$(visualstudio.version)\Community\Common7\Tools\VsDevCmd.bat
+        arguments: -no_logo -arch=x64 -host_arch=x64
+        modifyEnvironment: true
+      displayName: 'vcvarsall.bat'
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '2.7.x'
+    - script: |
+        echo "##vso[task.setvariable variable=PATH]$(install.directory)/bin;%PATH%"
+      displayName: 'Update PATH'
+    # TODO(compnerd) figure out how to account for patches to these files
+    - script: |
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/ucrt.modulemap" -o "%UniversalCRTSdkDir%/Include/%UCRTVersion%/ucrt/module.modulemap"
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.modulemap" -o "%VCToolsInstallDir%/include/module.modulemap"
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.apinotes" -o "%VCToolsInstallDir%/include/visualc.apinotes"
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/winsdk.modulemap" -o "%UniversalCRTSdkDir%/Include/%UCRTVersion%/um/module.modulemap"
+      displayName: 'Configure SDK'
+    - task: DownloadBuildArtifacts@0
+      inputs:
+        buildType: specific
+        project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
+        allowPartiallySucceededBuilds: true
+        pipeline: 9
+        artifactName: 'icu-$(platform)-$(host)'
+        downloadPath: '$(Build.StagingDirectory)'
+      displayName: 'Install ICU'
+    - template: templates/toolchain.yml
+    - script: |
+        echo ##vso[task.setvariable variable=PATH]$(icu.directory)/usr/bin;$(install.directory)\bin;$(Build.StagingDirectory)\swift\libdispatch-prefix\bin;%PATH%;%ProgramFiles%\Git\usr\bin
+      displayName: 'Update PATH'
+    - task: CMake@1
+      inputs:
+        cmakeArgs: --build $(Build.StagingDirectory)\toolchain --target check-swift
+      displayName: 'test swift'
+      continueOnError: true
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFormat: 'JUnit'
+        testResultsFiles: '$(Build.StagingDirectory)/toolchain/swift-test-results/*/*.xml'

--- a/.ci/windows-sdk-facebook-vs2017.yml
+++ b/.ci/windows-sdk-facebook-vs2017.yml
@@ -1,0 +1,228 @@
+pr:
+  branches:
+    include:
+      - master
+  paths:
+    include:
+      - .ci/windows-sdk-facebook.yml
+      - .ci/templates/windows-sdk.yml
+trigger:
+  branches:
+    include:
+      - master
+  paths:
+    include:
+      - .ci/windows-sdk-facebook.yml
+      - .ci/templates/windows-sdk.yml
+jobs:
+  - job: windows_armv7
+    condition: false
+    pool: Facebook-VS2017
+    variables:
+      arch: armv7
+      host: arm
+      platform: windows
+      triple: armv7-unknown-windows-msvc
+
+      toolchain.version: development
+      toolchain.directory: $(System.ArtifactsDirectory)/toolchain/Developer/Toolchains/unknown-Asserts-$(toolchain.version).xctoolchain
+
+      curl.version: development
+      curl.directory: $(System.ArtifactsDirectory)/curl-windows-$(host)/libcurl-$(curl.version)
+
+      icu.version: 64
+      icu.directory: $(System.ArtifactsDirectory)/icu-windows-$(host)/ICU-$(icu.version)
+
+      xml2.version: development
+      xml2.directory: $(System.ArtifactsDirectory)/xml2-windows-$(host)/libxml2-$(xml2.version)
+
+      zlib.version: 1.2.11
+      zlib.directory: $(System.ArtifactsDirectory)/zlib-windows-$(host)/zlib-$(zlib.version)
+
+      platform.directory: $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform
+      install.directory: $(platform.directory)/Developer/SDKs/Windows.sdk/usr
+      xctest.version: development
+      xctest.install.directory: $(platform.directory)/Developer/Library/XCTest-$(xctest.version)/usr
+
+      sqlite.version: 3.28.0
+      sqlite.directory: $(System.ArtifactsDirectory)/sqlite-windows-$(host)/sqlite-$(sqlite.version)
+
+      llbuild.version: development
+      llbuild.install.directory: $(Build.StagingDirectory)/Library/Developer/SharedSupport/llbuild-$(llbuild.version)/usr
+
+      visualstudio.version: 2017
+    steps:
+    - task: BatchScript@1
+      inputs:
+        filename: C:\Program Files (x86)\Microsoft Visual Studio\$(visualstudio.version)\Community\Common7\Tools\VsDevCmd.bat
+        arguments: -no_logo -arch=arm -host_arch=x64
+        modifyEnvironment: true
+      displayName: 'vcvarsall.bat'
+    - script: |
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/ucrt.modulemap" -o "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap"
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.modulemap" -o "%VCToolsInstallDir%\include\module.modulemap"
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.apinotes" -o "%VCToolsInstallDir%\include\visualc.apinotes"
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/winsdk.modulemap" -o "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap"
+      displayName: 'Configure SDK'
+    - script: |
+        echo "##vso[task.setvariable variable=PATH]$(toolchain.directory)/usr/bin;%PATH%"
+      displayName: 'Update PATH'
+    - template: templates/windows-sdk.yml
+
+  - job: windows_arm64
+    condition: false
+    # TODO(compnerd) move to Facebook pool
+    pool: Default
+    variables:
+      arch: aarch64
+      host: arm64
+      platform: windows
+      triple: aarch64-unknown-windows-msvc
+
+      toolchain.version: development
+      toolchain.directory: $(System.ArtifactsDirectory)/toolchain/Developer/Toolchains/unknown-Asserts-$(toolchain.version).xctoolchain
+
+      curl.version: development
+      curl.directory: $(System.ArtifactsDirectory)/curl-windows-$(host)/libcurl-$(curl.version)
+
+      icu.version: 64
+      icu.directory: $(System.ArtifactsDirectory)/icu-windows-$(host)/ICU-$(icu.version)
+
+      xml2.version: development
+      xml2.directory: $(System.ArtifactsDirectory)/xml2-windows-$(host)/libxml2-$(xml2.version)
+
+      zlib.version: 1.2.11
+      zlib.directory: $(System.ArtifactsDirectory)/zlib-windows-$(host)/zlib-$(zlib.version)
+
+      platform.directory: $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform
+      install.directory: $(platform.directory)/Developer/SDKs/Windows.sdk/usr
+      xctest.version: development
+      xctest.install.directory: $(platform.directory)/Developer/Library/XCTest-$(xctest.version)/usr
+
+      sqlite.version: 3.28.0
+      sqlite.directory: $(System.ArtifactsDirectory)/sqlite-windows-$(host)/sqlite-$(sqlite.version)
+
+      llbuild.version: development
+      llbuild.install.directory: $(Build.StagingDirectory)/Library/Developer/SharedSupport/llbuild-$(llbuild.version)/usr
+    steps:
+    - task: BatchScript@1
+      inputs:
+        filename: C:\Program Files (x86)\Microsoft Visual Studio\$(visualstudio.version)\Community\Common7\Tools\VsDevCmd.bat
+        arguments: -no_logo -arch=arm64 -host_arch=x64
+        modifyEnvironment: true
+      displayName: 'vcvarsall.bat'
+    - script: |
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/ucrt.modulemap" -o "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap"
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.modulemap" -o "%VCToolsInstallDir%\include\module.modulemap"
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.apinotes" -o "%VCToolsInstallDir%\include\visualc.apinotes"
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/winsdk.modulemap" -o "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap"
+      displayName: 'Configure SDK'
+    - script: |
+        echo "##vso[task.setvariable variable=PATH]$(toolchain.directory)/usr/bin;%PATH%"
+      displayName: 'Update PATH'
+    - template: templates/windows-sdk.yml
+
+  - job: windows_x64
+    # TODO(compnerd) move to Facebook pool
+    pool: Default
+    variables:
+      arch: x86_64
+      host: x64
+      platform: windows
+      triple: x86_64-unknown-windows-msvc
+
+      toolchain.version: development
+      toolchain.directory: $(System.ArtifactsDirectory)/toolchain/Developer/Toolchains/unknown-Asserts-$(toolchain.version).xctoolchain
+
+      curl.version: development
+      curl.directory: $(System.ArtifactsDirectory)/curl-windows-x64/libcurl-$(curl.version)
+
+      icu.version: 64
+      icu.directory: $(System.ArtifactsDirectory)/icu-windows-x64/ICU-$(icu.version)
+
+      xml2.version: development
+      xml2.directory: $(System.ArtifactsDirectory)/xml2-windows-x64/libxml2-$(xml2.version)
+
+      zlib.version: 1.2.11
+      zlib.directory: $(System.ArtifactsDirectory)/zlib-windows-x64/zlib-$(zlib.version)
+
+      platform.directory: $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform
+      install.directory: $(platform.directory)/Developer/SDKs/Windows.sdk/usr
+      xctest.version: development
+      xctest.install.directory: $(platform.directory)/Developer/Library/XCTest-$(xctest.version)/usr
+
+      sqlite.version: 3.28.0
+      sqlite.directory: $(System.ArtifactsDirectory)/sqlite-windows-x64/sqlite-$(sqlite.version)
+
+      llbuild.version: development
+      llbuild.install.directory: $(Build.StagingDirectory)/Library/Developer/SharedSupport/llbuild-$(llbuild.version)/usr
+    steps:
+    - task: BatchScript@1
+      inputs:
+        filename: C:\Program Files (x86)\Microsoft Visual Studio\$(visualstudio.version)\Community\Common7\Tools\VsDevCmd.bat
+        arguments: -no_logo -arch=x64 -host_arch=x64
+        modifyEnvironment: true
+      displayName: 'vcvarsall.bat'
+    - script: |
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/ucrt.modulemap" -o "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap"
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.modulemap" -o "%VCToolsInstallDir%\include\module.modulemap"
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.apinotes" -o "%VCToolsInstallDir%\include\visualc.apinotes"
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/winsdk.modulemap" -o "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap"
+      displayName: 'Configure SDK'
+    - script: |
+        echo "##vso[task.setvariable variable=PATH]$(toolchain.directory)/usr/bin;%PATH%"
+      displayName: 'Update PATH'
+    - template: templates/windows-sdk.yml
+
+  - job: windows_x86
+    condition: false
+    # TODO(compnerd) move to Facebook pool
+    pool: Default
+    variables:
+      arch: i686
+      host: x86
+      platform: windows
+      triple: i686-unknown-windows-msvc
+
+      toolchain.version: development
+      toolchain.directory: $(System.ArtifactsDirectory)/toolchain/Developer/Toolchains/unknown-Asserts-$(toolchain.version).xctoolchain
+
+      curl.version: development
+      curl.directory: $(System.ArtifactsDirectory)/curl-windows-$(host)/libcurl-$(curl.version)
+
+      icu.version: 64
+      icu.directory: $(System.ArtifactsDirectory)/icu-windows-$(host)/ICU-$(icu.version)
+
+      xml2.version: development
+      xml2.directory: $(System.ArtifactsDirectory)/xml2-windows-$(host)/libxml2-$(xml2.version)
+
+      zlib.version: 1.2.11
+      zlib.directory: $(System.ArtifactsDirectory)/zlib-windows-$(host)/zlib-$(zlib.version)
+
+      platform.directory: $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform
+      install.directory: $(platform.directory)/Developer/SDKs/Windows.sdk/usr
+      xctest.version: development
+      xctest.install.directory: $(platform.directory)/Developer/Library/XCTest-$(xctest.version)/usr
+
+      sqlite.version: 3.28.0
+      sqlite.directory: $(System.ArtifactsDirectory)/sqlite-windows-$(host)/sqlite-$(sqlite.version)
+
+      llbuild.version: development
+      llbuild.install.directory: $(Build.StagingDirectory)/Library/Developer/SharedSupport/llbuild-$(llbuild.version)/usr
+    steps:
+    - task: BatchScript@1
+      inputs:
+        filename: C:\Program Files (x86)\Microsoft Visual Studio\$(visualstudio.version)\Community\Common7\Tools\VsDevCmd.bat
+        arguments: -no_logo -arch=x86 -host_arch=x64
+        modifyEnvironment: true
+      displayName: 'vcvarsall.bat'
+    - script: |
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/ucrt.modulemap" -o "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap"
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.modulemap" -o "%VCToolsInstallDir%\include\module.modulemap"
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.apinotes" -o "%VCToolsInstallDir%\include\visualc.apinotes"
+        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/winsdk.modulemap" -o "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap"
+      displayName: 'Configure SDK'
+    - script: |
+        echo "##vso[task.setvariable variable=PATH]$(toolchain.directory)/usr/bin;%PATH%"
+      displayName: 'Update PATH'
+    - template: templates/windows-sdk.yml

--- a/.ci/windows-sdk-facebook-vs2019.yml
+++ b/.ci/windows-sdk-facebook-vs2019.yml
@@ -17,8 +17,7 @@ trigger:
 jobs:
   - job: windows_armv7
     condition: false
-    # TODO(compnerd) move to Facebook pool
-    pool: Default
+    pool: Facebook-VS2019
     variables:
       arch: armv7
       host: arm
@@ -50,10 +49,12 @@ jobs:
 
       llbuild.version: development
       llbuild.install.directory: $(Build.StagingDirectory)/Library/Developer/SharedSupport/llbuild-$(llbuild.version)/usr
+
+      visualstudio.version: 2019
     steps:
     - task: BatchScript@1
       inputs:
-        filename: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat
+        filename: C:\Program Files (x86)\Microsoft Visual Studio\$(visualstudio.version)\Community\Common7\Tools\VsDevCmd.bat
         arguments: -no_logo -arch=arm -host_arch=x64
         modifyEnvironment: true
       displayName: 'vcvarsall.bat'
@@ -106,7 +107,7 @@ jobs:
     steps:
     - task: BatchScript@1
       inputs:
-        filename: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat
+        filename: C:\Program Files (x86)\Microsoft Visual Studio\$(visualstudio.version)\Community\Common7\Tools\VsDevCmd.bat
         arguments: -no_logo -arch=arm64 -host_arch=x64
         modifyEnvironment: true
       displayName: 'vcvarsall.bat'
@@ -158,7 +159,7 @@ jobs:
     steps:
     - task: BatchScript@1
       inputs:
-        filename: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat
+        filename: C:\Program Files (x86)\Microsoft Visual Studio\$(visualstudio.version)\Community\Common7\Tools\VsDevCmd.bat
         arguments: -no_logo -arch=x64 -host_arch=x64
         modifyEnvironment: true
       displayName: 'vcvarsall.bat'
@@ -211,7 +212,7 @@ jobs:
     steps:
     - task: BatchScript@1
       inputs:
-        filename: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat
+        filename: C:\Program Files (x86)\Microsoft Visual Studio\$(visualstudio.version)\Community\Common7\Tools\VsDevCmd.bat
         arguments: -no_logo -arch=x86 -host_arch=x64
         modifyEnvironment: true
       displayName: 'vcvarsall.bat'


### PR DESCRIPTION
@compnerd I haven't changed the current agent from "Default" to "Facebook-VS2017", to avoid breaking the current behaviour. If you want to merge this, I can bring down the agent and register it again in the right pool.
