### PR TITLE
Provide schedules in cron format in YAML.

### DIFF
--- a/.ci/toolchain-vs2017-amd64-facebook.yml
+++ b/.ci/toolchain-vs2017-amd64-facebook.yml
@@ -14,6 +14,19 @@ trigger:
     include:
       - .ci/azure-pipelines-aws-agent.yml
       - .ci/templates/toolchain.yml
+schedules:
+- cron: "0 */3 * * *"
+  displayName: "O'clock builds"
+  branches:
+    include:
+    - master
+  always: true
+- cron: "30 1-22/3 * * *"
+  displayName: "Half past builds"
+  branches:
+    include:
+    - master
+  always: true
 jobs:
   - job: windows_x64
     timeoutInMinutes: 120

--- a/.ci/toolchain-vs2019-amd64-facebook.yml
+++ b/.ci/toolchain-vs2019-amd64-facebook.yml
@@ -14,6 +14,19 @@ trigger:
     include:
       - .ci/azure-pipelines-aws-agent.yml
       - .ci/templates/toolchain.yml
+schedules:
+- cron: "0 */3 * * *"
+  displayName: "O'clock builds"
+  branches:
+    include:
+    - master
+  always: true
+- cron: "30 1-22/3 * * *"
+  displayName: "Half past builds"
+  branches:
+    include:
+    - master
+  always: true
 jobs:
   - job: windows_x64
     timeoutInMinutes: 120


### PR DESCRIPTION
This will need removing the existing schedules in the UI for the VS2017 build.

I don’t know how to test this, but the VS2017 pipeline will use the UI, so that one will not break, and we can see if I screw up the syntax in the VS2019 pipeline (which has no schedules in the UI at the moment).