### PR TITLE
SDK: make pipeline a substitution

### DIFF
--- a/.ci/templates/windows-sdk.yml
+++ b/.ci/templates/windows-sdk.yml
@@ -44,7 +44,7 @@ steps:
       buildType: specific
       project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
       allowPartiallySucceededBuilds: true
-      pipeline: 1
+      pipeline: $(toolchain.pipeline)
       artifactName: 'toolchain'
       downloadPath: '$(System.ArtifactsDirectory)'
     displayName: 'Install toolchain'

--- a/.ci/windows-sdk-facebook-vs2017.yml
+++ b/.ci/windows-sdk-facebook-vs2017.yml
@@ -51,6 +51,8 @@ jobs:
       llbuild.install.directory: $(Build.StagingDirectory)/Library/Developer/SharedSupport/llbuild-$(llbuild.version)/usr
 
       visualstudio.version: 2017
+
+      toolchain.pipeline: 5
     steps:
     - task: BatchScript@1
       inputs:
@@ -103,6 +105,10 @@ jobs:
 
       llbuild.version: development
       llbuild.install.directory: $(Build.StagingDirectory)/Library/Developer/SharedSupport/llbuild-$(llbuild.version)/usr
+
+      visualstudio.version: 2017
+
+      toolchain.pipeline: 5
     steps:
     - task: BatchScript@1
       inputs:
@@ -154,6 +160,10 @@ jobs:
 
       llbuild.version: development
       llbuild.install.directory: $(Build.StagingDirectory)/Library/Developer/SharedSupport/llbuild-$(llbuild.version)/usr
+
+      visualstudio.version: 2017
+
+      toolchain.pipeline: 5
     steps:
     - task: BatchScript@1
       inputs:
@@ -206,6 +216,10 @@ jobs:
 
       llbuild.version: development
       llbuild.install.directory: $(Build.StagingDirectory)/Library/Developer/SharedSupport/llbuild-$(llbuild.version)/usr
+
+      visualstudio.version: 2017
+
+      toolchain.pipeline: 5
     steps:
     - task: BatchScript@1
       inputs:

--- a/.ci/windows-sdk-facebook-vs2019.yml
+++ b/.ci/windows-sdk-facebook-vs2019.yml
@@ -51,6 +51,8 @@ jobs:
       llbuild.install.directory: $(Build.StagingDirectory)/Library/Developer/SharedSupport/llbuild-$(llbuild.version)/usr
 
       visualstudio.version: 2019
+
+      toolchain.pipeline: 31
     steps:
     - task: BatchScript@1
       inputs:
@@ -103,6 +105,10 @@ jobs:
 
       llbuild.version: development
       llbuild.install.directory: $(Build.StagingDirectory)/Library/Developer/SharedSupport/llbuild-$(llbuild.version)/usr
+
+      visualstudio.version: 2019
+
+      toolchain.pipeline: 31
     steps:
     - task: BatchScript@1
       inputs:
@@ -154,6 +160,10 @@ jobs:
 
       llbuild.version: development
       llbuild.install.directory: $(Build.StagingDirectory)/Library/Developer/SharedSupport/llbuild-$(llbuild.version)/usr
+
+      visualstudio.version: 2019
+
+      toolchain.pipeline: 31
     steps:
     - task: BatchScript@1
       inputs:
@@ -206,6 +216,10 @@ jobs:
 
       llbuild.version: development
       llbuild.install.directory: $(Build.StagingDirectory)/Library/Developer/SharedSupport/llbuild-$(llbuild.version)/usr
+
+      visualstudio.version: 2019
+
+      toolchain.pipeline: 31
     steps:
     - task: BatchScript@1
       inputs:

--- a/.ci/windows-sdk.yml
+++ b/.ci/windows-sdk.yml
@@ -57,6 +57,8 @@ jobs:
 
       llbuild.version: development
       llbuild.install.directory: $(Build.StagingDirectory)/Library/Developer/SharedSupport/llbuild-$(llbuild.version)/usr
+
+      toolchain.pipeline: 1
     steps:
     - task: BatchScript@1
       inputs:
@@ -110,6 +112,8 @@ jobs:
 
       llbuild.version: development
       llbuild.install.directory: $(Build.StagingDirectory)/Library/Developer/SharedSupport/llbuild-$(llbuild.version)/usr
+
+      toolchain.pipeline: 1
     steps:
     - task: BatchScript@1
       inputs:
@@ -162,6 +166,8 @@ jobs:
 
       llbuild.version: development
       llbuild.install.directory: $(Build.StagingDirectory)/Library/Developer/SharedSupport/llbuild-$(llbuild.version)/usr
+
+      toolchain.pipeline: 1
     steps:
     - task: BatchScript@1
       inputs:
@@ -215,6 +221,8 @@ jobs:
 
       llbuild.version: development
       llbuild.install.directory: $(Build.StagingDirectory)/Library/Developer/SharedSupport/llbuild-$(llbuild.version)/usr
+
+      toolchain.pipeline: 1
     steps:
     - task: BatchScript@1
       inputs:


### PR DESCRIPTION
The SDK should be built with the associated toolchain, so make a
parameter for that.