### PR TITLE
dependencies: template most dependencies, move to Azure

### DIFF
--- a/.ci/curl.yml
+++ b/.ci/curl.yml
@@ -22,195 +22,93 @@ trigger:
       - .ci/curl.yml
       - .ci/templates/curl.yml
 jobs:
-  - job: windows_armv7
-    pool:
-      vmImage: 'windows-2019'
-    variables:
+  - template: templates/curl.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
+
       arch: armv7
       host: arm
       platform: windows
 
-      curl.version: development
-      install.directory: $(Build.StagingDirectory)/Library/libcurl-$(curl.version)
-      curl.release: master
+  - template: templates/curl.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-      zlib.version: 1.2.11
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=arm -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/curl.yml
-
-  - job: windows_arm64
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: aarch64
       host: arm64
       platform: windows
 
-      curl.version: development
-      install.directory: $(Build.StagingDirectory)/Library/libcurl-$(curl.version)
-      curl.release: master
+  - template: templates/curl.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-      zlib.version: 1.2.11
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=arm64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/curl.yml
-
-  - job: windows_x64
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: x86_64
       host: x64
       platform: windows
 
-      curl.version: development
-      install.directory: $(Build.StagingDirectory)/Library/libcurl-$(curl.version)
-      curl.release: master
+  - template: templates/curl.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-      zlib.version: 1.2.11
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/curl.yml
-
-  - job: windows_x86
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: i686
       host: x86
       platform: windows
 
-      curl.version: development
-      install.directory: $(Build.StagingDirectory)/Library/libcurl-$(curl.version)
-      curl.release: master
+  - template: templates/curl.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-      zlib.version: 1.2.11
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x86 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/curl.yml
-
-  - job: android_armv7
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: armv7
       host: arm
       platform: android
 
-      curl.version: development
-      install.directory: $(Build.StagingDirectory)/Library/libcurl-$(curl.version)
-      curl.release: master
+  - template: templates/curl.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-      zlib.version: 1.2.11
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/curl.yml
-
-  - job: android_aarch64
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: aarch64
       host: arm64
       platform: android
 
-      curl.version: development
-      install.directory: $(Build.StagingDirectory)/Library/libcurl-$(curl.version)
-      curl.release: master
+  - template: templates/curl.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-      zlib.version: 1.2.11
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/curl.yml
-
-  - job: android_x64
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: x86_64
       host: x64
       platform: android
 
-      curl.version: development
-      install.directory: $(Build.StagingDirectory)/Library/libcurl-$(curl.version)
-      curl.release: master
 
-      zlib.version: 1.2.11
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/curl.yml
+  - template: templates/curl.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-
-  - job: android_x86
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: i686
       host: x86
       platform: android
 
-      curl.version: development
-      install.directory: $(Build.StagingDirectory)/Library/libcurl-$(curl.version)
-      curl.release: master
+  - template: templates/curl.yml
+    parameters:
+      pool:
+        vmImage: 'ubuntu-18.04'
 
-      zlib.version: 1.2.11
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/curl.yml
-
-  - job: linux_x64
-    pool: FlowKey
-    variables:
       arch: x86_64
       host: x64
       platform: linux
-
-      curl.version: development
-      install.directory: $(Build.StagingDirectory)/Library/libcurl-$(curl.version)
-      curl.release: master
-
-      zlib.version: 1.2.11
-    steps:
-    - template: templates/curl.yml
 

--- a/.ci/libxml2.yml
+++ b/.ci/libxml2.yml
@@ -22,175 +22,92 @@ trigger:
       - .ci/libxml2.yml
       - .ci/templates/libxml2.yml
 jobs:
-  - job: windows_armv7
-    pool:
-      vmImage: 'windows-2019'
-    variables:
+  - template: templates/libxml2.yml
+    parameters:
+      visualstudio: 2019/enterprise
+      pool:
+        vmimage: 'windows-2019'
+
       arch: armv7
       host: arm
       platform: windows
 
-      xml2.version: development
-      install.directory: $(Build.StagingDirectory)/Library/libxml2-$(XML2.Version)
-      xml2.release: cmake
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=arm -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/libxml2.yml
+  - template: templates/libxml2.yml
+    parameters:
+      visualstudio: 2019/enterprise
+      pool:
+        vmimage: 'windows-2019'
 
-  - job: windows_arm64
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: aarch64
       host: arm64
       platform: windows
 
-      xml2.version: development
-      install.directory: $(Build.StagingDirectory)/Library/libxml2-$(XML2.Version)
-      xml2.release: cmake
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=arm64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/libxml2.yml
+  - template: templates/libxml2.yml
+    parameters:
+      visualstudio: 2019/enterprise
+      pool:
+        vmimage: 'windows-2019'
 
-  - job: windows_x64
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: x86_64
       host: x64
       platform: windows
 
-      xml2.version: development
-      install.directory: $(Build.StagingDirectory)/Library/libxml2-$(XML2.Version)
-      xml2.release: cmake
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/libxml2.yml
+  - template: templates/libxml2.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: windows_x86
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: i686
       host: x86
       platform: windows
 
-      xml2.version: development
-      install.directory: $(Build.StagingDirectory)/Library/libxml2-$(XML2.Version)
-      xml2.release: cmake
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x86 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/libxml2.yml
+  - template: templates/libxml2.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: android_armv7
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: armv7
       host: arm
       platform: android
 
-      xml2.version: development
-      install.directory: $(Build.StagingDirectory)/Library/libxml2-$(XML2.Version)
-      xml2.release: cmake
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/libxml2.yml
+  - template: templates/libxml2.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: android_aarch64
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: aarch64
       host: arm64
       platform: android
 
-      xml2.version: development
-      install.directory: $(Build.StagingDirectory)/Library/libxml2-$(XML2.Version)
-      xml2.release: cmake
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/libxml2.yml
+  - template: templates/libxml2.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: android_x64
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: x86_64
       host: x64
       platform: android
 
-      xml2.version: development
-      install.directory: $(Build.StagingDirectory)/Library/libxml2-$(XML2.Version)
-      xml2.release: cmake
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/libxml2.yml
+  - template: templates/libxml2.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: android_x86
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: i686
       host: x86
       platform: android
 
-      xml2.version: development
-      install.directory: $(Build.StagingDirectory)/Library/libxml2-$(XML2.Version)
-      xml2.release: cmake
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/libxml2.yml
+  - template: templates/libxml2.yml
+    parameters:
+      pool:
+        vmImage: 'ubuntu-18.04'
 
-  - job: linux_x64
-    pool: FlowKey
-    variables:
       arch: x86_64
       host: x64
       platform: linux
 
-      xml2.version: development
-      install.directory: $(Build.StagingDirectory)/Library/libxml2-$(XML2.Version)
-      xml2.release: cmake
-    steps:
-    - template: templates/libxml2.yml

--- a/.ci/sqlite3.yml
+++ b/.ci/sqlite3.yml
@@ -22,175 +22,92 @@ trigger:
       - .ci/sqlite3.yml
       - .ci/templates/sqlite3.yml
 jobs:
-  - job: windows_armv7
-    pool:
-      vmImage: 'windows-2019'
-    variables:
+  - template: templates/sqlite3.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
+
       arch: armv7
       host: arm
       platform: windows
 
-      sqlite.version: 3.28.0
-      install.directory: $(Build.StagingDirectory)/Library/sqlite-$(sqlite.version)
-      sqlite.release: 3280000
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=arm -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/sqlite3.yml
+  - template: templates/sqlite3.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: windows_arm64
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: aarch64
       host: arm64
       platform: windows
 
-      sqlite.version: 3.28.0
-      install.directory: $(Build.StagingDirectory)/Library/sqlite-$(sqlite.version)
-      sqlite.release: 3280000
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=arm64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/sqlite3.yml
+  - template: templates/sqlite3.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: windows_x64
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: x86_64
       host: x64
       platform: windows
 
-      sqlite.version: 3.28.0
-      install.directory: $(Build.StagingDirectory)/Library/sqlite-$(sqlite.version)
-      sqlite.release: 3280000
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/sqlite3.yml
+  - template: templates/sqlite3.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: windows_x86
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: i686
       host: x86
       platform: windows
 
-      sqlite.version: 3.28.0
-      install.directory: $(Build.StagingDirectory)/Library/sqlite-$(sqlite.version)
-      sqlite.release: 3280000
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x86 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/sqlite3.yml
+  - template: templates/sqlite3.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: android_armv7
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: armv7
       host: arm
       platform: android
 
-      sqlite.version: 3.28.0
-      install.directory: $(Build.StagingDirectory)/Library/sqlite-$(sqlite.version)
-      sqlite.release: 3280000
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/sqlite3.yml
+  - template: templates/sqlite3.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: android_aarch64
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: aarch64
       host: arm64
       platform: android
 
-      sqlite.version: 3.28.0
-      install.directory: $(Build.StagingDirectory)/Library/sqlite-$(sqlite.version)
-      sqlite.release: 3280000
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/sqlite3.yml
+  - template: templates/sqlite3.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: android_x64
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: x86_64
       host: x64
       platform: android
 
-      sqlite.version: 3.28.0
-      install.directory: $(Build.StagingDirectory)/Library/sqlite-$(sqlite.version)
-      sqlite.release: 3280000
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/sqlite3.yml
+  - template: templates/sqlite3.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: android_x86
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: i686
       host: x86
       platform: android
 
-      sqlite.version: 3.28.0
-      install.directory: $(Build.StagingDirectory)/Library/sqlite-$(sqlite.version)
-      sqlite.release: 3280000
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/sqlite3.yml
+  - template: templates/sqlite3.yml
+    parameters:
+      pool:
+        vmImage: 'ubuntu-18.04'
 
-  - job: linux_x64
-    pool: FlowKey
-    variables:
       arch: x86_64
       host: x64
       platform: linux
 
-      sqlite.version: 3.28.0
-      install.directory: $(Build.StagingDirectory)/Library/sqlite-$(sqlite.version)
-      sqlite.release: 3280000
-    steps:
-    - template: templates/sqlite3.yml

--- a/.ci/templates/curl.yml
+++ b/.ci/templates/curl.yml
@@ -1,30 +1,56 @@
-steps:
-  - script: |
-      git clone --quiet --depth 1 --single-branch --branch $(curl.release) https://github.com/curl/curl.git curl
-    displayName: 'Fetch Sources'
-  - task: DownloadBuildArtifacts@0
-    inputs:
-      buildType: specific
-      project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
-      allowPartiallySucceededBuilds: true
-      pipeline: 16
-      artifactName: 'zlib-$(platform)-$(host)'
-      downloadPath: '$(System.ArtifactsDirectory)'
-    displayName: 'Install ZLIB'
-  - task: CMake@1
-    inputs:
-      workingDirectory: $(Build.StagingDirectory)/curl
-      cmakeArgs: -C $(Build.SourcesDirectory)/cmake/caches/curl.cmake -C $(Build.SourcesDirectory)/cmake/caches/$(platform)-$(arch).cmake -G Ninja $(Build.SourcesDirectory)/curl -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=$(install.directory)/usr -DZLIB_ROOT=$(System.ArtifactsDirectory)/zlib-$(platform)-$(host)/zlib-$(zlib.version)/usr -DBUILD_SHARED_LIBS=NO -DBUILD_TESTING=NO
-    displayName: 'Configure curl'
-  - task: CMake@1
-    inputs:
-      cmakeArgs: --build $(Build.StagingDirectory)/curl
-    displayName: 'Build CURL'
-  - task: CMake@1
-    inputs:
-      cmakeArgs: --build $(Build.StagingDirectory)/curl --target install
-    displayName: 'Install CURL'
-  - task: PublishBuildArtifacts@1
-    inputs:
-      pathtoPublish: $(Build.StagingDirectory)/Library
-      artifactName: curl-$(platform)-$(host)
+jobs:
+  - job: ${{ parameters.platform }}_${{ parameters.host }}
+    pool: ${{ parameters.pool }}
+    variables:
+      install.directory: $(Build.StagingDirectory)/Library/libcurl-development
+    steps:
+      - script: |
+          git clone --quiet --depth 1 --single-branch --branch master https://github.com/curl/curl.git curl
+        displayName: 'Fetch Sources'
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          buildType: specific
+          project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
+          allowPartiallySucceededBuilds: true
+          pipeline: 16
+          artifactName: 'zlib-${{ parameters.platform }}-${{ parameters.host }}'
+          downloadPath: '$(System.ArtifactsDirectory)'
+        displayName: 'Install ZLIB'
+      - task: BatchScript@1
+        inputs:
+          filename: C:/Program Files (x86)/Microsoft Visual Studio/${{ parameters.VisualStudio }}/Common7/Tools/VsDevCmd.bat
+          arguments: -no_logo -arch=${{ parameters.host }} -host_arch=x64
+          modifyEnvironment: true
+        condition: eq( variables['Agent.OS'], 'Windows_NT' )
+        displayName: 'vsvarsall.bat'
+      - script: |
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
+          sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+          sudo apt-get update
+          sudo apt-get -y install cmake ninja-build
+        condition: eq( variables['Agent.OS'], 'Linux' )
+        displayName: 'Install Dependencies'
+      - task: CMake@1
+        inputs:
+          workingDirectory: $(Build.StagingDirectory)/curl
+          cmakeArgs: -C $(Build.SourcesDirectory)/cmake/caches/curl.cmake -C $(Build.SourcesDirectory)/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}.cmake -G Ninja $(Build.SourcesDirectory)/curl -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=$(install.directory)/usr -DZLIB_ROOT=$(System.ArtifactsDirectory)/zlib-${{ parameters.platform }}-${{ parameters.host }}/zlib-1.2.11/usr -DBUILD_SHARED_LIBS=NO -DBUILD_TESTING=NO
+        # NOTE(compnerd) workaround old cmake installation on hosted agents
+        condition: not( eq( variables['Agent.OS'], 'Linux' ) )
+        displayName: 'Configure curl'
+      - script: |
+          /usr/bin/cmake -B $(Build.StagingDirectory)/curl -C $(Build.SourcesDirectory)/cmake/caches/curl.cmake -C $(Build.SourcesDirectory)/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}.cmake -G Ninja $(Build.SourcesDirectory)/curl -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=$(install.directory)/usr -DZLIB_ROOT=$(System.ArtifactsDirectory)/zlib-${{ parameters.platform }}-${{ parameters.host }}/zlib-1.2.11/usr -DBUILD_SHARED_LIBS=NO -DBUILD_TESTING=NO
+        # NOTE(compnerd) workaround old cmake installation on hosted agents
+        condition: eq( variables['Agent.OS'], 'Linux' )
+        displayName: 'Configure curl'
+      - task: CMake@1
+        inputs:
+          cmakeArgs: --build $(Build.StagingDirectory)/curl
+        displayName: 'Build CURL'
+      - task: CMake@1
+        inputs:
+          cmakeArgs: --build $(Build.StagingDirectory)/curl --target install
+        displayName: 'Install CURL'
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: $(Build.StagingDirectory)/Library
+          artifactName: curl-${{ parameters.platform }}-${{ parameters.host }}

--- a/.ci/templates/libxml2.yml
+++ b/.ci/templates/libxml2.yml
@@ -1,22 +1,41 @@
-steps:
-  - script: |
-      git clone --quiet --depth 1 --single-branch --branch $(xml2.release) https://github.com/compnerd/libxml2.git libxml2
-    displayName: 'Fetch Sources'
-  - task: CMake@1
-    inputs:
-      workingDirectory: $(Build.StagingDirectory)/libxml2
-      cmakeArgs: -G Ninja $(Build.SourcesDirectory)/libxml2 -C $(Build.SourcesDirectory)/cmake/caches/libxml2.cmake -C $(Build.SourcesDirectory)/cmake/caches/$(platform)-$(arch).cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=$(install.directory)/usr -DBUILD_SHARED_LIBS=NO -DENABLE_TESTING=NO
-    displayName: 'Configure XML2'
-  - task: CMake@1
-    inputs:
-      cmakeArgs: --build $(Build.StagingDirectory)/libxml2
-    displayName: 'Build XML2'
-  - task: CMake@1
-    inputs:
-      cmakeArgs: --build $(Build.StagingDirectory)/libxml2 --target install
-    displayName: 'Install XML2'
-  - task: PublishBuildArtifacts@1
-    inputs:
-      pathtoPublish: $(Build.StagingDirectory)/Library
-      artifactName: xml2-$(platform)-$(host)
+jobs:
+  - job: ${{ parameters.platform}}_${{ parameters.host }}
+    pool: ${{ parameters.pool }}
+    variables:
+      install.directory: $(Build.StagingDirectory)/Library/libxml2-development
+    steps:
+      - script: |
+          git clone --quiet --depth 1 --single-branch --branch cmake https://github.com/compnerd/libxml2.git libxml2
+        displayName: 'Fetch Sources'
+      - task: BatchScript@1
+        inputs:
+          filename: C:/Program Files (x86)/Microsoft Visual Studio/${{ parameters.VisualStudio }}/Common7/Tools/VsDevCmd.bat
+          arguments: -no_logo -arch=${{ parameters.host }} -host_arch=x64
+          modifyEnvironment: true
+        condition: eq( variables['Agent.OS'], 'Windows_NT' )
+        displayName: 'vsvarsall.bat'
+      - script: |
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
+          sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+          sudo apt-get update
+          sudo apt-get -y install cmake ninja-build
+        condition: eq( variables['Agent.OS'], 'Linux' )
+        displayName: 'Install Dependencies'
+      - task: CMake@1
+        inputs:
+          workingDirectory: $(Build.StagingDirectory)/libxml2
+          cmakeArgs: -C $(Build.SourcesDirectory)/cmake/caches/libxml2.cmake -C $(Build.SourcesDirectory)/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}.cmake -G Ninja $(Build.SourcesDirectory)/libxml2 -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=$(install.directory)/usr -DBUILD_SHARED_LIBS=NO -DENABLE_TESTING=NO
+        displayName: 'Configure XML2'
+      - task: CMake@1
+        inputs:
+          cmakeArgs: --build $(Build.StagingDirectory)/libxml2
+        displayName: 'Build XML2'
+      - task: CMake@1
+        inputs:
+          cmakeArgs: --build $(Build.StagingDirectory)/libxml2 --target install
+        displayName: 'Install XML2'
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: $(Build.StagingDirectory)/Library
+          artifactName: xml2-${{ parameters.platform }}-${{ parameters.host }}
 

--- a/.ci/templates/sqlite3.yml
+++ b/.ci/templates/sqlite3.yml
@@ -1,33 +1,53 @@
-steps:
-  - powershell: |
-      Invoke-WebRequest -UseBasicParsing -Uri https://sqlite.org/2019/sqlite-amalgamation-$(sqlite.release).zip -OutFile $(Build.SourcesDirectory)\sqlite-amalgamation-$(sqlite.release).zip
-    displayName: 'Download Sources'
-  - task: ExtractFiles@1
-    inputs:
-      archiveFilePatterns: $(Build.SourcesDirectory)/sqlite-amalgamation-$(sqlite.release).zip
-      destinationFolder: $(Build.SourcesDirectory)
-      cleanDestinationFolder: false
-    displayName: 'Extract Sources'
-  - task: CopyFiles@2
-    inputs:
-      SourceFolder: $(Build.SourcesDirectory)/cmake/SQLite
-      contents: CMakeLists.txt
-      TargetFolder: $(Build.SourcesDirectory)/sqlite-amalgamation-$(sqlite.release)
-    displayName: 'Prepare'
-  - task: CMake@1
-    inputs:
-      workingDirectory: $(Build.StagingDirectory)/sqlite
-      cmakeArgs: -G Ninja $(Build.SourcesDirectory)/sqlite-amalgamation-$(sqlite.release) -C $(Build.SourcesDirectory)/cmake/caches/$(platform)-$(arch).cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=$(install.directory)/usr -DBUILD_SHARED_LIBS=NO
-    displayName: 'Configure SQLite3'
-  - task: CMake@1
-    inputs:
-      cmakeArgs: --build $(Build.StagingDirectory)/sqlite
-    displayName: 'Build SQLite3'
-  - task: CMake@1
-    inputs:
-      cmakeArgs: --build $(Build.StagingDirectory)/sqlite --target install
-    displayName: 'Install SQLite3'
-  - task: PublishBuildArtifacts@1
-    inputs:
-      pathtoPublish: $(Build.StagingDirectory)/Library
-      artifactName: sqlite-$(platform)-$(host)
+jobs:
+  - job: ${{ parameters.platform }}_${{ parameters.host }}
+    pool: ${{ parameters.pool }}
+    variables:
+      sqlite.release: 3280000
+      install.directory: $(Build.StagingDirectory)/Library/sqlite-3.28.0
+    steps:
+      - powershell: |
+          Invoke-WebRequest -UseBasicParsing -Uri https://sqlite.org/2019/sqlite-amalgamation-$(sqlite.release).zip -OutFile $(Build.SourcesDirectory)/sqlite-amalgamation-$(sqlite.release).zip
+        displayName: 'Download Sources'
+      - task: ExtractFiles@1
+        inputs:
+          archiveFilePatterns: $(Build.SourcesDirectory)/sqlite-amalgamation-$(sqlite.release).zip
+          destinationFolder: $(Build.SourcesDirectory)
+          cleanDestinationFolder: false
+        displayName: 'Extract Sources'
+      - task: CopyFiles@2
+        inputs:
+          SourceFolder: $(Build.SourcesDirectory)/cmake/SQLite
+          contents: CMakeLists.txt
+          TargetFolder: $(Build.SourcesDirectory)/sqlite-amalgamation-$(sqlite.release)
+        displayName: 'Prepare'
+      - task: BatchScript@1
+        inputs:
+          filename: C:/Program Files (x86)/Microsoft Visual Studio/${{ parameters.VisualStudio }}/Common7/Tools/VsDevCmd.bat
+          arguments: -no_logo -arch=${{ parameters.host }} -host_arch=x64
+          modifyEnvironment: true
+        condition: eq( variables['Agent.OS'], 'Windows_NT' )
+        displayName: 'vsvarsall.bat'
+      - script: |
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
+          sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+          sudo apt-get update
+          sudo apt-get -y install cmake ninja-build
+        condition: eq( variables['Agent.OS'], 'Linux' )
+        displayName: 'Install Dependencies'
+      - task: CMake@1
+        inputs:
+          workingDirectory: $(Build.StagingDirectory)/sqlite
+          cmakeArgs: -C $(Build.SourcesDirectory)/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}.cmake -G Ninja $(Build.SourcesDirectory)/sqlite-amalgamation-$(sqlite.release) -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=$(install.directory)/usr -DBUILD_SHARED_LIBS=NO
+        displayName: 'Configure SQLite3'
+      - task: CMake@1
+        inputs:
+          cmakeArgs: --build $(Build.StagingDirectory)/sqlite
+        displayName: 'Build SQLite3'
+      - task: CMake@1
+        inputs:
+          cmakeArgs: --build $(Build.StagingDirectory)/sqlite --target install
+        displayName: 'Install SQLite3'
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: $(Build.StagingDirectory)/Library
+          artifactName: sqlite-${{ parameters.platform }}-${{ parameters.host }}

--- a/.ci/templates/zlib.yml
+++ b/.ci/templates/zlib.yml
@@ -1,22 +1,40 @@
-steps:
-  - script: |
-      git clone --quiet --depth 1 --single-branch https://github.com/madler/zlib.git zlib
-      git -C zlib checkout $(zlib.release)
-    displayName: 'Fetch Sources'
-  - task: CMake@1
-    inputs:
-      workingDirectory: $(Build.StagingDirectory)/zlib
-      cmakeArgs: -G Ninja $(Build.SourcesDirectory)/zlib -C $(Build.SourcesDirectory)/cmake/caches/$(platform)-$(arch).cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=$(install.directory)/usr -DBUILD_SHARED_LIBS=NO -DBUILD_TESTING=NO
-    displayName: 'Configure zlib'
-  - task: CMake@1
-    inputs:
-      cmakeArgs: --build $(Build.StagingDirectory)/zlib
-    displayName: 'Build zlib'
-  - task: CMake@1
-    inputs:
-      cmakeArgs: --build $(Build.StagingDirectory)/zlib --target install
-    displayName: 'Install zlib'
-  - task: PublishBuildArtifacts@1
-    inputs:
-      pathtoPublish: $(Build.StagingDirectory)/Library
-      artifactName: zlib-$(platform)-$(host)
+jobs:
+  - job: ${{ parameters.platform }}_${{ parameters.host }}
+    pool: ${{ parameters.pool }}
+    variables:
+      install.directory: $(Build.StagingDirectory)/Library/zlib-1.2.11
+    steps:
+      - script: |
+          git clone --quiet --depth 1 --single-branch --branch v1.2.11 https://github.com/madler/zlib.git zlib
+        displayName: 'Fetch Sources'
+      - task: BatchScript@1
+        inputs:
+          filename: C:/Program Files (x86)/Microsoft Visual Studio/${{ parameters.VisualStudio }}/Common7/Tools/VsDevCmd.bat
+          arguments: -no_logo -arch=${{ parameters.host }} -host_arch=x64
+          modifyEnvironment: true
+        condition: eq( variables['Agent.OS'], 'Windows_NT' )
+        displayName: 'vsvarsall.bat'
+      - script: |
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
+          sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+          sudo apt-get update
+          sudo apt-get -y install cmake ninja-build
+        condition: eq( variables['Agent.OS'], 'Linux' )
+        displayName: 'Install Dependencies'
+      - task: CMake@1
+        inputs:
+          workingDirectory: $(Build.StagingDirectory)/zlib
+          cmakeArgs: -C $(Build.SourcesDirectory)/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}.cmake -G Ninja $(Build.SourcesDirectory)/zlib -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=$(install.directory)/usr -DBUILD_SHARED_LIBS=NO -DBUILD_TESTING=NO
+        displayName: 'Configure zlib'
+      - task: CMake@1
+        inputs:
+          cmakeArgs: --build $(Build.StagingDirectory)/zlib
+        displayName: 'Build zlib'
+      - task: CMake@1
+        inputs:
+          cmakeArgs: --build $(Build.StagingDirectory)/zlib --target install
+        displayName: 'Install zlib'
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: $(Build.StagingDirectory)/Library
+          artifactName: zlib-${{ parameters.platform }}-${{ parameters.host }}

--- a/.ci/zlib.yml
+++ b/.ci/zlib.yml
@@ -22,175 +22,91 @@ trigger:
       - .ci/zlib.yml
       - .ci/templates/zlib.yml
 jobs:
-  - job: windows_armv7
-    pool:
-      vmImage: 'windows-2019'
-    variables:
+  - template: templates/zlib.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
+
       arch: armv7
       host: arm
       platform: windows
 
-      zlib.version: 1.2.11
-      install.directory: $(Build.StagingDirectory)/Library/zlib-$(zlib.version)
-      zlib.release: v1.2.11
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=arm -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/zlib.yml
+  - template: templates/zlib.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: windows_arm64
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: aarch64
       host: arm64
       platform: windows
 
-      zlib.version: 1.2.11
-      install.directory: $(Build.StagingDirectory)/Library/zlib-$(zlib.version)
-      zlib.release: v1.2.11
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=arm64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/zlib.yml
+  - template: templates/zlib.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: windows_x64
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: x86_64
       host: x64
       platform: windows
 
-      zlib.version: 1.2.11
-      install.directory: $(Build.StagingDirectory)/Library/zlib-$(zlib.version)
-      zlib.release: v1.2.11
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/zlib.yml
+  - template: templates/zlib.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: windows_x86
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: i686
       host: x86
       platform: windows
 
-      zlib.version: 1.2.11
-      install.directory: $(Build.StagingDirectory)/Library/zlib-$(zlib.version)
-      zlib.release: v1.2.11
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x86 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/zlib.yml
+  - template: templates/zlib.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: android_armv7
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: armv7
       host: arm
       platform: android
 
-      zlib.version: 1.2.11
-      install.directory: $(Build.StagingDirectory)/Library/zlib-$(zlib.version)
-      zlib.release: v1.2.11
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/zlib.yml
+  - template: templates/zlib.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: android_aarch64
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: aarch64
       host: arm64
       platform: android
 
-      zlib.version: 1.2.11
-      install.directory: $(Build.StagingDirectory)/Library/zlib-$(zlib.version)
-      zlib.release: v1.2.11
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/zlib.yml
+  - template: templates/zlib.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: android_x64
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: x86_64
       host: x64
       platform: android
 
-      zlib.version: 1.2.11
-      install.directory: $(Build.StagingDirectory)/Library/zlib-$(zlib.version)
-      zlib.release: v1.2.11
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/zlib.yml
+  - template: templates/zlib.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-  - job: android_x86
-    pool:
-      vmImage: 'windows-2019'
-    variables:
       arch: i686
       host: x86
       platform: android
 
-      zlib.version: 1.2.11
-      install.directory: $(Build.StagingDirectory)/Library/zlib-$(zlib.version)
-      zlib.release: v1.2.11
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - template: templates/zlib.yml
+  - template: templates/zlib.yml
+    parameters:
+      pool:
+        vmImage: 'ubuntu-18.04'
 
-  - job: linux_x64
-    pool: FlowKey
-    variables:
       arch: x86_64
       host: x64
       platform: linux
-
-      zlib.version: 1.2.11
-      install.directory: $(Build.StagingDirectory)/Library/zlib-$(zlib.version)
-      zlib.release: v1.2.11
-    steps:
-    - template: templates/zlib.yml


### PR DESCRIPTION
This moves everything to azure, uses templates to build the images.
This simplifies the dependency builds.  It may also enable us to finally
add Linux arm, aarch64 builds.