### PR TITLE
xml2: improvements

### DIFF
--- a/.ci/linux-sdk.yml
+++ b/.ci/linux-sdk.yml
@@ -29,7 +29,7 @@ jobs:
       curl.directory: $(Pipeline.Workspace)/Library/libcurl-development
       icu.version: 64
       icu.directory: $(System.ArtifactsDirectory)/icu-linux-$(host)/icu-$(icu.version)
-      xml2.directory: $(System.ArtifactsDirectory)/xml2-linux-$(host)/libxml2-development
+      xml2.directory: $(Pipeline.Workspace)/Library/libxml2-development
       install.directory: $(Build.StagingDirectory)/Library/Developer/Platforms/Linux.platform/Developer/SDKs/Linux.sdk/usr
       xctest.install.directory: $(Build.StagingDirectory)/Library/Developer/Platforms/Linux.platform/Developer/Library/XCTest-development/usr
       zlib.directory: $(Pipeline.Workspace)/Library/zlib-1.2.11

--- a/.ci/templates/android-sdk.yml
+++ b/.ci/templates/android-sdk.yml
@@ -8,11 +8,11 @@ jobs:
     pool: ${{ parameters.pool }}
     variables:
       toolchain.directory: $(System.ArtifactsDirectory)/toolchain/Developer/Toolchains/unknown-Asserts-development.xctoolchain
-      curl.directory: $(System.ArtifactsDirectory)/curl-android-${{ parameters.host }}/libcurl-development
+      curl.directory: $(Pipeline.Workspace)/Library/libcurl-development
       icu.version: 64
       icu.directory: $(System.ArtifactsDirectory)/icu-android-${{ parameters.host }}/ICU-$(icu.version)
-      xml2.directory: $(System.ArtifactsDirectory)/xml2-android-${{ parameters.host }}/libxml2-development
-      zlib.directory: $(System.ArtifactsDirectory)/zlib-android-${{ parameters.host }}/zlib-1.2.11
+      xml2.directory: $(Pipeline.Workspace)/Library/libxml2-development
+      zlib.directory: $(Pipeline.Workspace)/Library/zlib-1.2.11
       install.directory: $(Build.StagingDirectory)/Library/Developer/Platforms/Android.platform/Developer/SDKs/Android.sdk/usr
       xctest.install.directory: $(Build.StagingDirectory)/Library/Developer/Platforms/Android.platform/Developer/Library/XCTest-development/usr
     steps:
@@ -66,32 +66,29 @@ jobs:
           artifactName: 'icu-android-${{ parameters.host }}'
           downloadPath: '$(System.ArtifactsDirectory)'
         displayName: 'Install ICU'
-      - task: DownloadBuildArtifacts@0
+      - task: DownloadPipelineArtifact@2
         inputs:
-          buildType: specific
+          source: 'specific'
           project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
           pipeline: 10
-          allowPartiallySucceededBuilds: true
+          runVersion: 'latest'
           artifactName: 'xml2-android-${{ parameters.host }}'
-          downloadPath: '$(System.ArtifactsDirectory)'
         displayName: 'Install XML2'
-      - task: DownloadBuildArtifacts@0
+      - task: DownloadPipelineArtifact@2
         inputs:
-          buildType: specific
+          source: 'specific'
           project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
           pipeline: 16
-          allowPartiallySucceededBuilds: true
+          runVersion: 'latest'
           artifactName: 'zlib-android-${{ parameters.host }}'
-          downloadPath: '$(System.ArtifactsDirectory)'
         displayName: 'Install ZLIB'
-      - task: DownloadBuildArtifacts@0
+      - task: DownloadPipelineArtifact@2
         inputs:
-          buildType: specific
+          source: 'specific'
           project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
           pipeline: 11
-          allowPartiallySucceededBuilds: true
+          runVersion: 'latest'
           artifactName: 'curl-android-${{ parameters.host }}'
-          downloadPath: '$(System.ArtifactsDirectory)'
         displayName: 'Install CURL'
       - task: BatchScript@1
         inputs:

--- a/.ci/templates/libxml2.yml
+++ b/.ci/templates/libxml2.yml
@@ -2,10 +2,10 @@ jobs:
   - job: ${{ parameters.platform}}_${{ parameters.host }}
     pool: ${{ parameters.pool }}
     variables:
-      install.directory: $(Build.StagingDirectory)/Library/libxml2-development
+      install.directory: $(Build.StagingDirectory)/xml2-${{ parameters.platform }}-${{ parameters.host }}/Library/libxml2-development
     steps:
       - script: |
-          git clone --quiet --depth 1 --single-branch --branch cmake https://github.com/compnerd/libxml2.git libxml2
+          git clone --quiet --depth 1 --single-branch --branch cmake https://github.com/compnerd/libxml2.git $(Build.SourcesDirectory)/libxml2
         displayName: 'Fetch Sources'
       - task: BatchScript@1
         inputs:
@@ -23,19 +23,19 @@ jobs:
         displayName: 'Install Dependencies'
       - task: CMake@1
         inputs:
-          workingDirectory: $(Build.StagingDirectory)/libxml2
+          workingDirectory: $(Build.BinariesDirectory)/libxml2
           cmakeArgs: -C $(Build.SourcesDirectory)/cmake/caches/libxml2.cmake -C $(Build.SourcesDirectory)/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}.cmake -G Ninja $(Build.SourcesDirectory)/libxml2 -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=$(install.directory)/usr -DBUILD_SHARED_LIBS=NO -DENABLE_TESTING=NO
         displayName: 'Configure XML2'
       - task: CMake@1
         inputs:
-          cmakeArgs: --build $(Build.StagingDirectory)/libxml2
+          cmakeArgs: --build $(Build.BinariesDirectory)/libxml2
         displayName: 'Build XML2'
       - task: CMake@1
         inputs:
-          cmakeArgs: --build $(Build.StagingDirectory)/libxml2 --target install
+          cmakeArgs: --build $(Build.BinariesDirectory)/libxml2 --target install
         displayName: 'Install XML2'
-      - task: PublishBuildArtifacts@1
+      - task: PublishPipelineArtifact@1
         inputs:
-          pathtoPublish: $(Build.StagingDirectory)/Library
-          artifactName: xml2-${{ parameters.platform }}-${{ parameters.host }}
+          path: $(Build.StagingDirectory)/xml2-${{ parameters.platform }}-${{ parameters.host }}
+          artifact: xml2-${{ parameters.platform }}-${{ parameters.host }}
 

--- a/.ci/templates/linux-sdk.yml
+++ b/.ci/templates/linux-sdk.yml
@@ -52,15 +52,14 @@ steps:
       artifactName: 'icu-linux-$(host)'
       downloadPath: '$(System.ArtifactsDirectory)'
     displayName: 'Install ICU'
-  - task: DownloadBuildArtifacts@0
+  - task: DownloadPipelineArtifact@2
     inputs:
-      buildType: specific
+      source: 'specific'
       project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
-      allowPartiallySucceededBuilds: true
       pipeline: 10
+      runVersion: 'latest'
       artifactName: 'xml2-linux-$(host)'
-      downloadPath: '$(System.ArtifactsDirectory)'
-    displayName: 'Install libXML2'
+    displayName: 'Install XML2'
   - task: DownloadPipelineArtifact@2
     inputs:
       source: 'specific'

--- a/.ci/templates/windows-sdk.yml
+++ b/.ci/templates/windows-sdk.yml
@@ -13,7 +13,7 @@ jobs:
       curl.directory: $(Pipeline.Workspace)/Library/libcurl-development
       icu.version: 64
       icu.directory: $(System.ArtifactsDirectory)/icu-windows-${{ parameters.host }}/ICU-$(icu.version)
-      xml2.directory: $(System.ArtifactsDirectory)/xml2-windows-${{ parameters.host }}/libxml2-development
+      xml2.directory: $(Pipeline.Workspace)/Library/libxml2-development
       zlib.directory: $(Pipeline.Workspace)/Library/zlib-1.2.11
       install.directory: $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk/usr
       xctest.install.directory: $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Developer/Library/XCTest-development/usr
@@ -68,14 +68,13 @@ jobs:
           artifactName: 'icu-windows-${{ parameters.host }}'
           downloadPath: '$(System.ArtifactsDirectory)'
         displayName: 'Install ICU'
-      - task: DownloadBuildArtifacts@0
+      - task: DownloadPipelineArtifact@2
         inputs:
-          buildType: specific
+          source: 'specific'
           project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
           pipeline: 10
-          allowPartiallySucceededBuilds: true
+          runVersion: 'latest'
           artifactName: 'xml2-windows-${{ parameters.host }}'
-          downloadPath: '$(System.ArtifactsDirectory)'
         displayName: 'Install XML2'
       - task: DownloadPipelineArtifact@2
         inputs:


### PR DESCRIPTION
- use BinariesDirectory for build
- use SourcesDirectory for sources
- use PublishPipelineArtifacts to publish
- use DownloadPipelineArtifacts to consume