### PR TITLE
toolchain: template and homogenise

### DIFF
--- a/.ci/linux-devtools.yml
+++ b/.ci/linux-devtools.yml
@@ -25,7 +25,7 @@ jobs:
       sqlite.directory: $(Pipeline.Workspace)/Library/sqlite-3.30.1
 
       toolchain.version: development
-      toolchain.directory: $(System.ArtifactsDirectory)/toolchain/Developer/Toolchains/unknown-Asserts-$(toolchain.version).xctoolchain
+      toolchain.directory: $(Pipeline.Workspace)/Library/Developer/Toolchains/unknown-Asserts-$(toolchain.version).xctoolchain
 
       platform.directory: $(Build.StagingDirectory)/Library/Developer/Platforms/Linux.platform
 

--- a/.ci/linux-sdk.yml
+++ b/.ci/linux-sdk.yml
@@ -25,7 +25,7 @@ jobs:
       host: x64
       triple: x86_64-unknown-linux-gnu
 
-      toolchain.directory: $(System.ArtifactsDirectory)/toolchain/Developer/Toolchains/unknown-Asserts-development.xctoolchain
+      toolchain.directory: $(Pipeline.Workspace)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
       curl.directory: $(Pipeline.Workspace)/Library/libcurl-development
       icu.version: 64
       icu.directory: $(System.ArtifactsDirectory)/icu-linux-$(host)/icu-$(icu.version)

--- a/.ci/templates/android-sdk.yml
+++ b/.ci/templates/android-sdk.yml
@@ -7,7 +7,7 @@ jobs:
   - job: ${{ parameters.host }}
     pool: ${{ parameters.pool }}
     variables:
-      toolchain.directory: $(System.ArtifactsDirectory)/toolchain/Developer/Toolchains/unknown-Asserts-development.xctoolchain
+      toolchain.directory: $(Pipeline.Workspace)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
       curl.directory: $(Pipeline.Workspace)/Library/libcurl-development
       icu.version: 64
       icu.directory: $(System.ArtifactsDirectory)/icu-android-${{ parameters.host }}/ICU-$(icu.version)
@@ -48,14 +48,13 @@ jobs:
           endlocal
           goto :eof
         displayName: 'Fetch Sources'
-      - task: DownloadBuildArtifacts@0
+      - task: DownloadPipelineArtifact@2
         inputs:
-          buildType: specific
+          source: 'specific'
           project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
-          allowPartiallySucceededBuilds: true
           pipeline: ${{ parameters.toolchain }}
-          artifactName: 'toolchain'
-          downloadPath: '$(System.ArtifactsDirectory)'
+          runVersion: 'latest'
+          artifactName: 'toolchain-android-${{ parameters.host }}'
         displayName: 'Install toolchain'
       - task: DownloadBuildArtifacts@0
         inputs:

--- a/.ci/templates/linux-devtools.yml
+++ b/.ci/templates/linux-devtools.yml
@@ -23,14 +23,13 @@ steps:
       git clone --quiet --config core.symlinks=true --depth 1 --single-branch https://github.com/apple/indexstore-db indexstore-db
       ApplyPatches indexstore-db ${INDEXSTOREDB_PR}
     displayName: 'Fetch Sources'
-  - task: DownloadBuildArtifacts@0
+  - task: DownloadPipelineArtifact@2
     inputs:
-      buildType: specific
+      source: 'specific'
       project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
-      allowPartiallySucceededBuilds: true
       pipeline: 14
-      artifactName: 'toolchain'
-      downloadPath: '$(System.ArtifactsDirectory)'
+      runVersion: 'latest'
+      artifactName: 'toolchain-$(platform)-$(host)'
     displayName: 'Install toolchain'
   - script: |
       chmod +x $(toolchain.directory)/usr/bin/ar

--- a/.ci/templates/linux-sdk.yml
+++ b/.ci/templates/linux-sdk.yml
@@ -24,15 +24,14 @@ steps:
       git clone --quiet --depth 1 --single-branch https://github.com/apple/swift-corelibs-xctest swift-corelibs-xctest
       ApplyPatches swift-corelibs-xctest ${XCTEST_PR}
     displayName: 'Fetch Sources'
-  - task: DownloadBuildArtifacts@0
+  - task: DownloadPipelineArtifact@2
     inputs:
-      buildType: specific
+      source: 'specific'
       project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
-      allowPartiallySucceededBuilds: true
       pipeline: 14
-      artifactName: 'toolchain'
-      downloadPath: '$(System.ArtifactsDirectory)'
-    displayName: 'Install toolchain'
+      runVersion: 'latest'
+      artifactName: 'toolchain-linux-$(host)'
+    displayName: 'Install CURL'
   - script: |
       chmod +x $(toolchain.directory)/usr/bin/ar
       chmod +x $(toolchain.directory)/usr/bin/clang

--- a/.ci/templates/toolchain.yml
+++ b/.ci/templates/toolchain.yml
@@ -1,43 +1,135 @@
-steps:
-  - script: |
-      git config --global user.name 'builder'
-      git config --global user.email 'builder@compnerd.org'
+jobs:
+  - job: ${{ parameters.host }}
+    pool: ${{ parameters.pool }}
+    timeoutInMinutes: 0
+    variables:
+      icu.version: 64
+      icu.directory: $(System.ArtifactsDirectory)/icu-${{ parameters.platform }}-${{ parameters.host }}/icu-$(icu.version)
 
-      git clone --quiet --depth 1 --single-branch --branch swift/$(branch) https://github.com/apple/llvm-project toolchain
-
-      git clone --quiet --depth 1 --single-branch --branch $(branch) https://github.com/apple/swift-cmark toolchain/cmark
-      git clone --quiet --depth 1 --single-branch --branch $(branch) https://github.com/apple/swift-corelibs-libdispatch toolchain/swift-corelibs-libdispatch
-      git clone --config core.autocrlf=false --config core.symlinks=true --quiet --depth 1 --single-branch --branch $(branch) https://github.com/apple/swift toolchain/swift
-    displayName: 'Fetch Sources'
-  - task: CMake@1
-    inputs:
-      workingDirectory: $(Build.StagingDirectory)/llvm-tools
-      cmakeArgs: -C $(Build.SourcesDirectory)/cmake/caches/$(platform)-$(arch).cmake -G Ninja $(Build.SourcesDirectory)/toolchain/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=NO -DLLVM_ENABLE_PROJECTS="clang"
-    displayName: 'Configure LLVM Build Tools'
-  - task: CMake@1
-    inputs:
-      cmakeArgs: --build $(Build.StagingDirectory)/llvm-tools --target llvm-tblgen
-    displayName: 'Build LLVM Build Tools'
-  - task: CMake@1
-    inputs:
-      cmakeArgs: --build $(Build.StagingDirectory)/llvm-tools --target clang-tblgen
-    displayName: 'Build Clang Build Tools'
-  - task: CMake@1
-    inputs:
-      workingDirectory: $(Build.StagingDirectory)/toolchain
-      cmakeArgs: -C $(Build.SourcesDirectory)/cmake/caches/$(platform)-$(arch).cmake -C $(Build.SourcesDirectory)/cmake/caches/org.compnerd.dt.cmake -G Ninja $(Build.SourcesDirectory)/toolchain/llvm -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(install.directory) -DLLVM_DEFAULT_TARGET_TRIPLE=$(triple) -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;cmark;swift;lldb;lld" -DLLVM_EXTERNAL_PROJECTS="cmark;swift" -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE=$(Build.SourcesDirectory)/toolchain/swift-corelibs-libdispatch $(llvm.extra_cmake_flags) $(lldb.extra_cmake_flags) $(swift.extra_cmake_flags)
-    displayName: 'Configure toolchain'
-  - task: CMake@1
-    inputs:
-      cmakeArgs: --build $(Build.StagingDirectory)/toolchain --target distribution
-    displayName: 'Build toolchain'
-  - task: CMake@1
-    inputs:
-      cmakeArgs: --build $(Build.StagingDirectory)/toolchain --target install-distribution
-    displayName: 'Install toolchain'
-  - task: PublishBuildArtifacts@1
-    inputs:
-      pathtoPublish: $(Build.StagingDirectory)/Library
-      parallel: true
-      parallelCount: 8
-      artifactName: toolchain
+      install.directory: $(Build.StagingDirectory)/toolchain-${{ parameters.platform }}-${{ parameters.host }}/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
+    steps:
+      - script: |
+          set -eu
+          curl -Ls https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-mac.zip -o ninja-mac.zip
+          unzip ninja-mac.zip
+          sudo cp -v ninja /usr/local/bin/
+        condition: eq( variables['Agent.OS'], 'Darwin' )
+        displayName: 'Install Dependencies'
+      - task: Bash@3
+        inputs:
+          targetType: inline
+          script: '/usr/bin/sccache --start-server || true'
+        env: { 'SCCACHE_REDIS': 'redis://localhost' }
+        condition: eq( variables['Agent.Name'], 'swift-ci' )
+        displayName: 'enable redis'
+      - script: |
+          git config --global --add core.autocrlf false
+          git config --global --add core.symlinks true
+        condition: eq( variables['Agent.OS'], 'Windows_NT' )
+        displayName: 'Enable symbols, disable line ending conversion'
+      - checkout: self
+      - checkout: apple/llvm-project
+        path: s/toolchain
+      - checkout: apple/swift-cmark
+        path: s/toolchain/cmark
+      - checkout: apple/swift-corelibs-libdispatch
+      - checkout: apple/swift
+        path: s/toolchain/swift
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          buildType: specific
+          project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
+          allowPartiallySucceededBuilds: true
+          pipeline: 9
+          artifactName: 'icu-${{ parameters.platform }}-${{ parameters.host }}'
+          downloadPath: '$(System.ArtifactsDirectory)'
+        condition: not( eq( variables['Agent.OS'], 'Darwin' ) )
+        displayName: 'Install ICU'
+      - task: BatchScript@1
+        inputs:
+          filename: C:/Program Files (x86)/Microsoft Visual Studio/${{ parameters.VisualStudio }}/Common7/Tools/VsDevCmd.bat
+          arguments: -no_logo -arch=x64 -host_arch=x64
+          modifyEnvironment: true
+        condition: eq( variables['Agent.OS'], 'Windows_NT' )
+        displayName: 'vsvarsall.bat'
+      - task: CMake@1
+        inputs:
+          workingDirectory: $(Build.BinariesDirectory)/llvm-tools
+          cmakeArgs: -C $(Build.SourcesDirectory)/windows-swift/cmake/caches/${{ parameters.platform }}-x86_64.cmake -G Ninja $(Build.SourcesDirectory)/toolchain/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=NO -DLLVM_ENABLE_PROJECTS="clang;lldb" -DLLDB_DISABLE_PYTHON=YES -DLLDB_INCLUDE_TESTS=NO
+        displayName: 'Configure LLVM Build Tools'
+      - task: CMake@1
+        inputs:
+          cmakeArgs: --build $(Build.BinariesDirectory)/llvm-tools --target llvm-tblgen
+        displayName: 'Build LLVM Build Tools'
+      - task: CMake@1
+        inputs:
+          cmakeArgs: --build $(Build.BinariesDirectory)/llvm-tools --target clang-tblgen
+        displayName: 'Build Clang Build Tools'
+      - task: CMake@1
+        inputs:
+          cmakeArgs: --build $(Build.BinariesDirectory)/llvm-tools --target lldb-tblgen
+        displayName: 'Build LLDB Build Tools'
+      - task: BatchScript@1
+        inputs:
+          filename: C:/Program Files (x86)/Microsoft Visual Studio/${{ parameters.VisualStudio }}/Common7/Tools/VsDevCmd.bat
+          arguments: -no_logo -arch=${{ parameters.host }} -host_arch=x64
+          modifyEnvironment: true
+        condition: eq( variables['Agent.OS'], 'Windows_NT' )
+        displayName: 'vsvarsall.bat'
+      - script: |
+          copy $(Build.SourcesDirectory)\toolchain\swift\stdlib\public\Platform\ucrt.modulemap "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap"
+          copy $(Build.SourcesDirectory)\toolchain\swift\stdlib\public\Platform\visualc.modulemap "%VCToolsInstallDir%\include\module.modulemap"
+          copy $(Build.SourcesDirectory)\toolchain\swift\stdlib\public\Platform\visualc.apinotes "%VCToolsInstallDir%\include\visualc.apinotes"
+          copy $(Build.SourcesDirectory)\toolchain\swift\stdlib\public\Platform\winsdk.modulemap "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap"
+        condition: eq( variables['Agent.OS'], 'Windows_NT' )
+        displayName: 'Configure SDK'
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '2.7.x'
+        name: python
+        condition: not( eq( variables['Agent.Name'], 'swift-ci' ) )
+      - task: CMake@1
+        inputs:
+          workingDirectory: $(Build.BinariesDirectory)/toolchain
+          cmakeArgs: -C $(Build.SourcesDirectory)/windows-swift/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}.cmake -C $(Build.SourcesDirectory)/windows-swift/cmake/caches/org.compnerd.dt.cmake -G Ninja $(Build.SourcesDirectory)/toolchain/llvm -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(install.directory)/usr -DLLVM_DEFAULT_TARGET_TRIPLE=${{ parameters.triple }} -DLLVM_USE_HOST_TOOLS=NO -DLLVM_TABLEGEN=$(Build.BinariesDirectory)/llvm-tools/bin/llvm-tblgen.exe -DCLANG_TABLEGEN=$(Build.BinariesDirectory)/llvm-tools/bin/clang-tblgen.exe -DLLDB_TABLEGEN=$(Build.BinariesDirectory)/llvm-tools/bin/lldb-tblgen.exe -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;cmark;swift;lldb;lld" -DLLVM_EXTERNAL_PROJECTS="cmark;swift" -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE=$(Build.SourcesDirectory)/swift-corelibs-libdispatch ${{ parameters.LLVM_OPTIONS }} ${{ parameters.LLDB_OPTIONS }} ${{ parameters.SWIFT_OPTIONS }}
+        condition: eq( variables['Agent.OS'], 'Windows_NT' )
+        displayName: 'Configure toolchain'
+      - task: CMake@1
+        inputs:
+          workingDirectory: $(Build.BinariesDirectory)/toolchain
+          cmakeArgs: -C $(Build.SourcesDirectory)/windows-swift/cmake/caches/${{ parameters.platform }}-${{ parameters.arch }}.cmake -C $(Build.SourcesDirectory)/windows-swift/cmake/caches/org.compnerd.dt.cmake -G Ninja $(Build.SourcesDirectory)/toolchain/llvm -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(install.directory)/usr -DLLVM_DEFAULT_TARGET_TRIPLE=${{ parameters.triple }} -DLLVM_USE_HOST_TOOLS=NO -DLLVM_TABLEGEN=$(Build.BinariesDirectory)/llvm-tools/bin/llvm-tblgen -DCLANG_TABLEGEN=$(Build.BinariesDirectory)/llvm-tools/bin/clang-tblgen -DLLDB_TABLEGEN=$(Build.BinariesDirectory)/llvm-tools/bin/lldb-tblgen -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;cmark;swift;lldb;lld" -DLLVM_EXTERNAL_PROJECTS="cmark;swift" -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE=$(Build.SourcesDirectory)/swift-corelibs-libdispatch ${{ parameters.LLVM_OPTIONS }} ${{ parameters.LLDB_OPTIONS }} ${{ parameters.SWIFT_OPTIONS }}
+        condition: not( eq( variables['Agent.OS'], 'Windows_NT' ) )
+        displayName: 'Configure toolchain'
+      - task: CMake@1
+        inputs:
+          cmakeArgs: --build $(Build.BinariesDirectory)/toolchain --target distribution
+        displayName: 'Build toolchain'
+      - task: CMake@1
+        inputs:
+          cmakeArgs: --build $(Build.BinariesDirectory)/toolchain --target install-distribution-stripped
+        displayName: 'Install toolchain'
+      - task: PublishPipelineArtifact@1
+        inputs:
+          path: $(Build.StagingDirectory)/toolchain-${{ parameters.platform }}-${{ parameters.host }}
+          artifact: toolchain-${{ parameters.platform }}-${{ parameters.host }}
+      - script: |
+          echo ##vso[task.setvariable variable=PATH]$(icu.directory)/usr/bin;$(install.directory)/usr/bin;$(Build.StagingDirectory)/swift/libdispatch-prefix/bin;%PATH%;%ProgramFiles%/Git/usr/bin
+        condition: and( eq( variables['Agent.OS'], 'Windows_NT' ), eq( '${{ parameters.tests }}', 'true' ) )
+        displayName: 'Update PATH'
+      - script: |
+          echo ##vso[task.setvariable variable=PATH]$(icu.directory)/usr/bin:$(install.directory)/usr/bin:$(Build.StagingDirectory)/swift/libdispatch-prefix/bin:${PATH}
+        condition: and( eq( variables['Agent.OS'], 'Linux' ), eq( '${{ parameters.tests }}', 'true' ) )
+        displayName: 'Update PATH'
+      - task: CMake@1
+        inputs:
+          cmakeArgs: --build $(Build.BinariesDirectory)/toolchain --target check-swift
+        condition: eq( '${{ parameters.tests }}', 'true' )
+        displayName: 'check-swift'
+        continueOnError: true
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: '$(Build.BinariesDirectory)/toolchain/swift-test-results/*/*.xml'
+          buildPlatform: ${{ parameters.platform }}-${{ parameters.arch }}
+          buildConfiguration: ${{ parameters.VisualStudio }}
+        condition: eq( '${{ parameters.tests }}', 'true' )

--- a/.ci/templates/windows-devtools.yml
+++ b/.ci/templates/windows-devtools.yml
@@ -5,7 +5,7 @@ jobs:
     condition: eq( '${{ parameters.host }}', 'x64' )
     pool: ${{ parameters.pool }}
     variables:
-      toolchain.directory: $(System.ArtifactsDirectory)/toolchain/Developer/Toolchains/unknown-Asserts-development.xctoolchain
+      toolchain.directory: $(Pipeline.Workspace)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
       sqlite.directory: $(Pipeline.Workspace)/Library/sqlite-3.30.1
       install.directory: $(Build.StagingDirectory)/Library/Developer/Platforms/Windows.platform/Library/
     steps:
@@ -42,14 +42,13 @@ jobs:
           endlocal
           goto :eof
         displayName: 'Fetch Sources'
-      - task: DownloadBuildArtifacts@0
+      - task: DownloadPipelineArtifact@2
         inputs:
-          buildType: specific
+          source: 'specific'
           project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
-          allowPartiallySucceededBuilds: true
           pipeline: ${{ parameters.toolchain }}
-          artifactName: 'toolchain'
-          downloadPath: '$(System.ArtifactsDirectory)'
+          runVersion: 'latest'
+          artifactName: 'toolchain-windows-${{ parameters.host }}'
         displayName: 'Install toolchain'
       - task: DownloadBuildArtifacts@0
         inputs:

--- a/.ci/templates/windows-sdk.yml
+++ b/.ci/templates/windows-sdk.yml
@@ -9,7 +9,7 @@ jobs:
     condition: eq( '${{ parameters.host }}', 'x64' )
     pool: ${{ parameters.pool }}
     variables:
-      toolchain.directory: $(System.ArtifactsDirectory)/toolchain/Developer/Toolchains/unknown-Asserts-development.xctoolchain
+      toolchain.directory: $(Pipeline.Workspace)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain
       curl.directory: $(Pipeline.Workspace)/Library/libcurl-development
       icu.version: 64
       icu.directory: $(System.ArtifactsDirectory)/icu-windows-${{ parameters.host }}/ICU-$(icu.version)
@@ -50,14 +50,13 @@ jobs:
           endlocal
           goto :eof
         displayName: 'Fetch Sources'
-      - task: DownloadBuildArtifacts@0
+      - task: DownloadPipelineArtifact@2
         inputs:
-          buildType: specific
+          source: 'specific'
           project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
-          allowPartiallySucceededBuilds: true
-          pipeline: ${{ parameters.toolchain }}
-          artifactName: 'toolchain'
-          downloadPath: '$(System.ArtifactsDirectory)'
+          pipeline: ${{ paramters.toolchain }}
+          runVersion: 'latest'
+          artifactName: 'toolcahin-windows-${{ parameters.host }}'
         displayName: 'Install toolchain'
       - task: DownloadBuildArtifacts@0
         inputs:

--- a/.ci/toolchain-darwin-x64.yml
+++ b/.ci/toolchain-darwin-x64.yml
@@ -6,6 +6,25 @@ pr:
     include:
       - .ci/toolchain-darwin-x64.yml
       - .ci/templates/toolchain.yml
+resources:
+  repositories:
+    - repository: apple/llvm-project
+      type: github
+      name: apple/llvm-project
+      ref: refs/heads/swift/master
+      endpoint: GitHub
+    - repository: apple/swift-cmark
+      type: github
+      name: apple/swift-cmark
+      endpoint: GitHub
+    - repository: apple/swift-corelibs-libdispatch
+      type: github
+      name: apple/swift-corelibs-libdispatch
+      endpoint: GitHub
+    - repository: apple/swift
+      type: github
+      name: apple/swift
+      endpoint: GitHub
 schedules:
   - cron: "0 0 * * *"
     branches:
@@ -22,15 +41,10 @@ trigger:
       - .ci/toolchain-darwin-x64.yml
       - .ci/templates/toolchain.yml
 jobs:
-  - job: darwin_x64
-    # NOTE(compnerd) this is an open source project built on hosted machines, so
-    # this time out is actually 6 hours.  Sadly, this is not very long given the
-    # complexity of this build and the speed of the hosted machines
-    timeoutInMinutes: 0
-    pool: 
-      vmImage: macOS-10.14
-    variables:
-      branch: master
+  - template: templates/toolchain.yml
+    parameters:
+      pool:
+        vmImage: 'macOS-10.14'
 
       arch: x86_64
       host: x64
@@ -38,16 +52,6 @@ jobs:
 
       triple: x86_64-apple-macosx10.14
 
-      install.directory: $(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-
-      llvm.extra_cmake_flags: -DLLVM_INCLUDE_TESTS=NO
-      swift.extra_cmake_flags: ""
-      lldb.extra_cmake_flags: -DLLDB_USE_SYSTEM_DEBUGSERVER=ON -DLLDB_INCLUDE_TESTS=NO
-    steps:
-    - script: |
-        set -eu
-        curl -Ls https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-mac.zip -o ninja-mac.zip
-        unzip ninja-mac.zip
-        sudo cp -v ninja /usr/local/bin/
-      displayName: "Install Ninja"
-    - template: templates/toolchain.yml
+      LLVM_OPTIONS: -DLLVM_INCLUDE_TESTS=NO -DCLANG_INCLUDE_TEST=NO -DLLD_INCLUDE_TESTS=NO
+      LLDB_OPTIONS: -DLLDB_USE_SYSTEM_DEBUGSERVER=ON -DLLDB_INCLUDE_TESTS=NO
+      SWIFT_OPTIONS: -DSWIFT_INCLUDE_TESTS=NO

--- a/.ci/toolchain-linux-x64.yml
+++ b/.ci/toolchain-linux-x64.yml
@@ -7,6 +7,25 @@ pr:
       - .ci/toolchain-linux-x64.yml
       - .ci/templates/toolchain.yml
       - cmake/caches/org.compnerd.dt.cmake
+resources:
+  repositories:
+    - repository: apple/llvm-project
+      type: github
+      name: apple/llvm-project
+      ref: refs/heads/swift/master
+      endpoint: GitHub
+    - repository: apple/swift-cmark
+      type: github
+      name: apple/swift-cmark
+      endpoint: GitHub
+    - repository: apple/swift-corelibs-libdispatch
+      type: github
+      name: apple/swift-corelibs-libdispatch
+      endpoint: GitHub
+    - repository: apple/swift
+      type: github
+      name: apple/swift
+      endpoint: GitHub
 schedules:
   - cron: "0 * * * *"
     branches:
@@ -24,10 +43,10 @@ trigger:
       - .ci/templates/toolchain.yml
       - cmake/caches/org.compnerd.dt.cmake
 jobs:
-  - job: linux_x64
-    pool: FlowKey
-    variables:
-      branch: master
+  - template: templates/toolchain.yml
+    parameters:
+      pool: FlowKey
+      tests: true
 
       arch: x86_64
       host: x64
@@ -35,17 +54,4 @@ jobs:
 
       triple: x86_64-unknown-linux-gnu
 
-      install.directory: $(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-
-      llvm.extra_cmake_flags: ""
-      swift.extra_cmake_flags: ""
-      lldb.extra_cmake_flags: ""
-    steps:
-    - task: Bash@3
-      inputs:
-        targetType: inline
-        script: '/usr/bin/sccache --start-server || true'
-      env: { 'SCCACHE_REDIS': 'redis://localhost' }
-    - script: echo "##vso[task.setvariable variable=PATH]/home/ci/cmake-3.15.3-Linux-x86_64/bin:${PATH}"
-      displayName: 'CMake PATH adjustment'
-    - template: templates/toolchain.yml
+      SWIFT_OPTIONS: -DSWIFT_LINUX_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_LINUX_x86_64_ICU_UC=$(icu.directory)/usr/lib/libicuuc$(icu.version).a -DSWIFT_LINUX_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_LINUX_x86_64_ICU_I18N=$(icu.directory)/usr/lib/libicuin$(icu.version).a -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES

--- a/.ci/toolchain-vs2017-amd64-5.2.yml
+++ b/.ci/toolchain-vs2017-amd64-5.2.yml
@@ -6,6 +6,28 @@ pr:
     include:
       - .ci/toolchain-vs2017-amd64-5.2.yml
       - .ci/templates/toolchain.yml
+resources:
+  repositories:
+    - repository: apple/llvm-project
+      type: github
+      name: apple/llvm-project
+      ref: refs/heads/swift/swift-5.2-branch
+      endpoint: GitHub
+    - repository: apple/swift-cmark
+      type: github
+      name: apple/swift-cmark
+      ref: refs/heads/swift-5.2-branch
+      endpoint: GitHub
+    - repository: apple/swift-corelibs-libdispatch
+      type: github
+      name: apple/swift-corelibs-libdispatch
+      ref: refs/heads/swift-5.2-branch
+      endpoint: GitHub
+    - repository: apple/swift
+      type: github
+      name: apple/swift
+      ref: refs/heads/swift-5.2-branch
+      endpoint: GitHub
 schedules:
   - cron: "0 17 * * *"
     branches:
@@ -22,15 +44,12 @@ trigger:
       - .ci/toolchain-vs2017-amd64-5.2.yml
       - .ci/templates/toolchain.yml
 jobs:
-  - job: windows_x64
-    # NOTE(compnerd) this is an open source project built on hosted machines, so
-    # this time out is actually 6 hours.  Sadly, this is not very long given the
-    # complexity of this build and the speed of the hosted machines
-    timeoutInMinutes: 0
-    pool:
-      vmImage: 'VS2017-Win2016'
-    variables:
-      branch: swift-5.2-branch
+  - template: templates/toolchain.yml
+    parameters:
+      VisualStudio: 2017/Enterprise
+      pool:
+        vmImage: 'VS2017-Win2016'
+      tests: true
 
       arch: x86_64
       host: x64
@@ -38,58 +57,6 @@ jobs:
 
       triple: x86_64-unknown-windows-msvc
 
-      install.directory: $(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-
-      icu.version : 64
-      icu.directory: $(System.ArtifactsDirectory)/icu-$(platform)-$(host)/ICU-$(icu.version)
-
-      llvm.extra_cmake_flags: -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(pythonTools.pythonLocation)/python.exe
-      swift.extra_cmake_flags: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DLLVM_PARALLEL_LINK_JOBS=2 -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
-      lldb.extra_cmake_flags: -DLLDB_DISABLE_PYTHON=YES
-    steps:
-      - task: BatchScript@1
-        inputs:
-          filename: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat
-          arguments: -no_logo -arch=x64 -host_arch=x64
-          modifyEnvironment: true
-        displayName: 'vcvarsall.bat'
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '2.7.x'
-        name: pythonTools
-      - script: python -m pip install --upgrade flake8
-        displayName: 'Install flake8'
-      - script: |
-          echo "##vso[task.setvariable variable=PATH]$(install.directory)/bin;%PATH%"
-        displayName: 'Update PATH'
-      # TODO(compnerd) figure out how to account for patches to these files
-      - script: |
-          curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/ucrt.modulemap" -o "%UniversalCRTSdkDir%/Include/%UCRTVersion%/ucrt/module.modulemap"
-          curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.modulemap" -o "%VCToolsInstallDir%/include/module.modulemap"
-          curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.apinotes" -o "%VCToolsInstallDir%/include/visualc.apinotes"
-          curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/winsdk.modulemap" -o "%UniversalCRTSdkDir%/Include/%UCRTVersion%/um/module.modulemap"
-        displayName: 'Configure SDK'
-      - task: DownloadBuildArtifacts@0
-        inputs:
-          buildType: specific
-          project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
-          allowPartiallySucceededBuilds: true
-          pipeline: 9
-          artifactName: 'icu-$(platform)-$(host)'
-          downloadPath: '$(Build.StagingDirectory)'
-        displayName: 'Install ICU'
-      - template: templates/toolchain.yml
-      - script: |
-          echo ##vso[task.setvariable variable=PATH]$(icu.directory)/usr/bin;$(Build.StagingDirectory)/swift/libdispatch-prefix/bin;%PATH%;%ProgramFiles%/Git/usr/bin
-        displayName: 'Update PATH'
-      - task: CMake@1
-        inputs:
-          cmakeArgs: --build $(Build.StagingDirectory)\toolchain --target check-swift
-        displayName: 'test swift'
-        continueOnError: true
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFormat: 'JUnit'
-          testResultsFiles: '$(Build.StagingDirectory)/toolchain/swift-test-results/*/*.xml'
-          buildPlatform: 'Windows-x86_64'
-          buildConfiguration: 'VS2017'
+      LLVM_OPTIONS: -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+      LLDB_OPTIONS: -DLLDB_DISABLE_PYTHON=YES
+      SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES

--- a/.ci/toolchain-vs2017-amd64-facebook.yml
+++ b/.ci/toolchain-vs2017-amd64-facebook.yml
@@ -14,6 +14,25 @@ trigger:
     include:
       - .ci/toolchain-vs2017-amd64-facebook.yml
       - .ci/templates/toolchain.yml
+resources:
+  repositories:
+    - repository: apple/llvm-project
+      type: github
+      name: apple/llvm-project
+      ref: refs/heads/swift/master
+      endpoint: GitHub
+    - repository: apple/swift-cmark
+      type: github
+      name: apple/swift-cmark
+      endpoint: GitHub
+    - repository: apple/swift-corelibs-libdispatch
+      type: github
+      name: apple/swift-corelibs-libdispatch
+      endpoint: GitHub
+    - repository: apple/swift
+      type: github
+      name: apple/swift
+      endpoint: GitHub
 schedules:
 - cron: "0 */3 * * *"
   displayName: "O'clock builds"
@@ -28,11 +47,11 @@ schedules:
     - master
   always: true
 jobs:
-  - job: windows_x64
-    timeoutInMinutes: 120
-    pool: Facebook-VS2017
-    variables:
-      branch: master
+  - template: templates/toolchain.yml
+    parameters:
+      VisualStudio: 2017/Community
+      pool: Facebook-VS2017
+      tests: true
 
       arch: x86_64
       host: x64
@@ -40,55 +59,6 @@ jobs:
 
       triple: x86_64-unknown-windows-msvc
 
-      install.directory: $(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-
-      icu.version : 64
-      icu.directory: $(System.ArtifactsDirectory)/icu-$(platform)-$(host)/ICU-$(icu.version)
-
-      llvm.extra_cmake_flags: -DLLVM_PARALLEL_LINK_JOBS=2
-      swift.extra_cmake_flags: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=8 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
-      lldb.extra_cmake_flags: -DLLDB_DISABLE_PYTHON=YES
-
-      visualstudio.version: 2017
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:\Program Files (x86)\Microsoft Visual Studio\$(visualstudio.version)\Community\Common7\Tools\VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '2.7.x'
-    - script: |
-        echo "##vso[task.setvariable variable=PATH]$(install.directory)/bin;%PATH%"
-      displayName: 'Update PATH'
-    # TODO(compnerd) figure out how to account for patches to these files
-    - script: |
-        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/ucrt.modulemap" -o "%UniversalCRTSdkDir%/Include/%UCRTVersion%/ucrt/module.modulemap"
-        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.modulemap" -o "%VCToolsInstallDir%/include/module.modulemap"
-        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.apinotes" -o "%VCToolsInstallDir%/include/visualc.apinotes"
-        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/winsdk.modulemap" -o "%UniversalCRTSdkDir%/Include/%UCRTVersion%/um/module.modulemap"
-      displayName: 'Configure SDK'
-    - task: DownloadBuildArtifacts@0
-      inputs:
-        buildType: specific
-        project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
-        allowPartiallySucceededBuilds: true
-        pipeline: 9
-        artifactName: 'icu-$(platform)-$(host)'
-        downloadPath: '$(Build.StagingDirectory)'
-      displayName: 'Install ICU'
-    - template: templates/toolchain.yml
-    - script: |
-        echo ##vso[task.setvariable variable=PATH]$(icu.directory)/usr/bin;$(install.directory)\bin;$(Build.StagingDirectory)\swift\libdispatch-prefix\bin;%PATH%;%ProgramFiles%\Git\usr\bin
-      displayName: 'Update PATH'
-    - task: CMake@1
-      inputs:
-        cmakeArgs: --build $(Build.StagingDirectory)\toolchain --target check-swift
-      displayName: 'test swift'
-      continueOnError: true
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFormat: 'JUnit'
-        testResultsFiles: '$(Build.StagingDirectory)/toolchain/swift-test-results/*/*.xml'
+      LLVM_OPTIONS: -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+      LLDB_OPTIONS: -DLLDB_DISABLE_PYTHON=YES
+      SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=8 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES

--- a/.ci/toolchain-vs2017-amd64.yml
+++ b/.ci/toolchain-vs2017-amd64.yml
@@ -6,6 +6,25 @@ pr:
     include:
       - .ci/toolchain-vs2017-amd64.yml
       - .ci/templates/toolchain.yml
+resources:
+  repositories:
+    - repository: apple/llvm-project
+      type: github
+      name: apple/llvm-project
+      ref: refs/heads/swift/master
+      endpoint: GitHub
+    - repository: apple/swift-cmark
+      type: github
+      name: apple/swift-cmark
+      endpoint: GitHub
+    - repository: apple/swift-corelibs-libdispatch
+      type: github
+      name: apple/swift-corelibs-libdispatch
+      endpoint: GitHub
+    - repository: apple/swift
+      type: github
+      name: apple/swift
+      endpoint: GitHub
 schedules:
   - cron: "0 0 * * *"
     branches:
@@ -22,15 +41,12 @@ trigger:
       - .ci/toolchain-vs2017-amd64.yml
       - .ci/templates/toolchain.yml
 jobs:
-  - job: windows_x64
-    # NOTE(compnerd) this is an open source project built on hosted machines, so
-    # this time out is actually 6 hours.  Sadly, this is not very long given the
-    # complexity of this build and the speed of the hosted machines
-    timeoutInMinutes: 0
-    pool:
-      vmImage: 'VS2017-Win2016'
-    variables:
-      branch: master
+  - template: templates/toolchain.yml
+    parameters:
+      VisualStudio: 2017/Enterprise
+      pool:
+        vmImage: 'VS2017-Win2016'
+      tests: true
 
       arch: x86_64
       host: x64
@@ -38,58 +54,6 @@ jobs:
 
       triple: x86_64-unknown-windows-msvc
 
-      install.directory: $(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-
-      icu.version : 64
-      icu.directory: $(System.ArtifactsDirectory)/icu-$(platform)-$(host)/ICU-$(icu.version)
-
-      llvm.extra_cmake_flags: -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(pythonTools.pythonLocation)/python.exe
-      swift.extra_cmake_flags: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DLLVM_PARALLEL_LINK_JOBS=2 -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
-      lldb.extra_cmake_flags: -DLLDB_DISABLE_PYTHON=YES
-    steps:
-      - task: BatchScript@1
-        inputs:
-          filename: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat
-          arguments: -no_logo -arch=x64 -host_arch=x64
-          modifyEnvironment: true
-        displayName: 'vcvarsall.bat'
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '2.7.x'
-        name: pythonTools
-      - script: python -m pip install --upgrade flake8
-        displayName: 'Install flake8'
-      - script: |
-          echo "##vso[task.setvariable variable=PATH]$(install.directory)/bin;%PATH%"
-        displayName: 'Update PATH'
-      # TODO(compnerd) figure out how to account for patches to these files
-      - script: |
-          curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/ucrt.modulemap" -o "%UniversalCRTSdkDir%/Include/%UCRTVersion%/ucrt/module.modulemap"
-          curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.modulemap" -o "%VCToolsInstallDir%/include/module.modulemap"
-          curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.apinotes" -o "%VCToolsInstallDir%/include/visualc.apinotes"
-          curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/winsdk.modulemap" -o "%UniversalCRTSdkDir%/Include/%UCRTVersion%/um/module.modulemap"
-        displayName: 'Configure SDK'
-      - task: DownloadBuildArtifacts@0
-        inputs:
-          buildType: specific
-          project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
-          allowPartiallySucceededBuilds: true
-          pipeline: 9
-          artifactName: 'icu-$(platform)-$(host)'
-          downloadPath: '$(Build.StagingDirectory)'
-        displayName: 'Install ICU'
-      - template: templates/toolchain.yml
-      - script: |
-          echo ##vso[task.setvariable variable=PATH]$(icu.directory)/usr/bin;$(Build.StagingDirectory)/swift/libdispatch-prefix/bin;%PATH%;%ProgramFiles%/Git/usr/bin
-        displayName: 'Update PATH'
-      - task: CMake@1
-        inputs:
-          cmakeArgs: --build $(Build.StagingDirectory)\toolchain --target check-swift
-        displayName: 'test swift'
-        continueOnError: true
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFormat: 'JUnit'
-          testResultsFiles: '$(Build.StagingDirectory)/toolchain/swift-test-results/*/*.xml'
-          buildPlatform: 'Windows-x86_64'
-          buildConfiguration: 'VS2017'
+      LLVM_OPTIONS: -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+      LLDB_OPTIONS: -DLLDB_DISABLE_PYTHON=YES
+      SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES

--- a/.ci/toolchain-vs2019-amd64-5.2.yml
+++ b/.ci/toolchain-vs2019-amd64-5.2.yml
@@ -6,6 +6,28 @@ pr:
     include:
       - .ci/toolchain-vs2019-amd64-5.2.yml
       - .ci/templates/toolchain.yml
+resources:
+  repositories:
+    - repository: apple/llvm-project
+      type: github
+      name: apple/llvm-project
+      ref: refs/heads/swift/swift-5.2-branch
+      endpoint: GitHub
+    - repository: apple/swift-cmark
+      type: github
+      name: apple/swift-cmark
+      ref: refs/heads/swift-5.2-branch
+      endpoint: GitHub
+    - repository: apple/swift-corelibs-libdispatch
+      type: github
+      name: apple/swift-corelibs-libdispatch
+      ref: refs/heads/swift-5.2-branch
+      endpoint: GitHub
+    - repository: apple/swift
+      type: github
+      name: apple/swift
+      ref: refs/heads/swift-5.2-branch
+      endpoint: GitHub
 schedules:
   - cron: "0 17 * * *"
     branches:
@@ -22,15 +44,12 @@ trigger:
       - .ci/toolchain-vs2019-amd64-5.2.yml
       - .ci/templates/toolchain.yml
 jobs:
-  - job: windows_x64
-    # NOTE(compnerd) this is an open source project built on hosted machines, so
-    # this time out is actually 6 hours.  Sadly, this is not very long given the
-    # complexity of this build and the speed of the hosted machines
-    timeoutInMinutes: 0
-    pool:
-      vmImage: 'windows-2019'
-    variables:
-      branch: swift-5.2-branch
+  - template: templates/toolchain.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
+      tests: true
 
       arch: x86_64
       host: x64
@@ -38,58 +57,6 @@ jobs:
 
       triple: x86_64-unknown-windows-msvc
 
-      install.directory: $(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-
-      icu.version : 64
-      icu.directory: $(System.ArtifactsDirectory)/icu-$(platform)-$(host)/ICU-$(icu.version)
-
-      llvm.extra_cmake_flags: -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(pythonTools.pythonLocation)/python.exe
-      swift.extra_cmake_flags: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DLLVM_PARALLEL_LINK_JOBS=2 -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
-      lldb.extra_cmake_flags: -DLLDB_DISABLE_PYTHON=YES
-    steps:
-      - task: BatchScript@1
-        inputs:
-          filename: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
-          arguments: -no_logo -arch=x64 -host_arch=x64
-          modifyEnvironment: true
-        displayName: 'vcvarsall.bat'
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '2.7.x'
-        name: pythonTools
-      - script: python -m pip install --upgrade flake8
-        displayName: 'Install flake8'
-      - script: |
-          echo "##vso[task.setvariable variable=PATH]$(install.directory)/bin;%PATH%"
-        displayName: 'Update PATH'
-      # TODO(compnerd) figure out how to account for patches to these files
-      - script: |
-          curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/ucrt.modulemap" -o "%UniversalCRTSdkDir%/Include/%UCRTVersion%/ucrt/module.modulemap"
-          curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.modulemap" -o "%VCToolsInstallDir%/include/module.modulemap"
-          curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.apinotes" -o "%VCToolsInstallDir%/include/visualc.apinotes"
-          curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/winsdk.modulemap" -o "%UniversalCRTSdkDir%/Include/%UCRTVersion%/um/module.modulemap"
-        displayName: 'Configure SDK'
-      - task: DownloadBuildArtifacts@0
-        inputs:
-          buildType: specific
-          project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
-          allowPartiallySucceededBuilds: true
-          pipeline: 9
-          artifactName: 'icu-$(platform)-$(host)'
-          downloadPath: '$(Build.StagingDirectory)'
-        displayName: 'Install ICU'
-      - template: templates/toolchain.yml
-      - script: |
-          echo ##vso[task.setvariable variable=PATH]$(icu.directory)/usr/bin;$(install.directory)\bin;$(Build.StagingDirectory)\swift\libdispatch-prefix\bin;%PATH%;%ProgramFiles%\Git\usr\bin
-        displayName: 'Update PATH'
-      - task: CMake@1
-        inputs:
-          cmakeArgs: --build $(Build.StagingDirectory)\toolchain --target check-swift
-        displayName: 'test swift'
-        continueOnError: true
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFormat: 'JUnit'
-          testResultsFiles: '$(Build.StagingDirectory)/toolchain/swift-test-results/*/*.xml'
-          buildPlatform: 'Windows-x86_64'
-          buildConfiguration: 'VS2019'
+      LLVM_OPTIONS: -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+      LLDB_OPTIONS: -DLLDB_DISABLE_PYTHON=YES
+      SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES

--- a/.ci/toolchain-vs2019-amd64-facebook.yml
+++ b/.ci/toolchain-vs2019-amd64-facebook.yml
@@ -6,14 +6,25 @@ pr:
     include:
       - .ci/toolchain-vs2019-amd64-facebook.yml
       - .ci/templates/toolchain.yml
-trigger:
-  branches:
-    include:
-      - master
-  paths:
-    include:
-      - .ci/toolchain-vs2019-amd64-facebook.yml
-      - .ci/templates/toolchain.yml
+resources:
+  repositories:
+    - repository: apple/llvm-project
+      type: github
+      name: apple/llvm-project
+      ref: refs/heads/swift/master
+      endpoint: GitHub
+    - repository: apple/swift-cmark
+      type: github
+      name: apple/swift-cmark
+      endpoint: GitHub
+    - repository: apple/swift-corelibs-libdispatch
+      type: github
+      name: apple/swift-corelibs-libdispatch
+      endpoint: GitHub
+    - repository: apple/swift
+      type: github
+      name: apple/swift
+      endpoint: GitHub
 schedules:
 - cron: "0 */3 * * *"
   displayName: "O'clock builds"
@@ -27,12 +38,20 @@ schedules:
     include:
     - master
   always: true
+trigger:
+  branches:
+    include:
+      - master
+  paths:
+    include:
+      - .ci/toolchain-vs2019-amd64-facebook.yml
+      - .ci/templates/toolchain.yml
 jobs:
-  - job: windows_x64
-    timeoutInMinutes: 120
-    pool: Facebook-VS2019
-    variables:
-      branch: master
+  - template: templates/toolchain.yml
+    parameters:
+      VisualStudio: 2019/Community
+      pool: Facebook-VS2019
+      tests: true
 
       arch: x86_64
       host: x64
@@ -40,55 +59,6 @@ jobs:
 
       triple: x86_64-unknown-windows-msvc
 
-      install.directory: $(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-
-      icu.version : 64
-      icu.directory: $(System.ArtifactsDirectory)/icu-$(platform)-$(host)/ICU-$(icu.version)
-
-      llvm.extra_cmake_flags: -DLLVM_PARALLEL_LINK_JOBS=2
-      swift.extra_cmake_flags: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=8 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
-      lldb.extra_cmake_flags: -DLLDB_DISABLE_PYTHON=YES
-
-      visualstudio.version: 2019
-    steps:
-    - task: BatchScript@1
-      inputs:
-        filename: C:\Program Files (x86)\Microsoft Visual Studio\$(visualstudio.version)\Community\Common7\Tools\VsDevCmd.bat
-        arguments: -no_logo -arch=x64 -host_arch=x64
-        modifyEnvironment: true
-      displayName: 'vcvarsall.bat'
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '2.7.x'
-    - script: |
-        echo "##vso[task.setvariable variable=PATH]$(install.directory)/bin;%PATH%"
-      displayName: 'Update PATH'
-    # TODO(compnerd) figure out how to account for patches to these files
-    - script: |
-        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/ucrt.modulemap" -o "%UniversalCRTSdkDir%/Include/%UCRTVersion%/ucrt/module.modulemap"
-        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.modulemap" -o "%VCToolsInstallDir%/include/module.modulemap"
-        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.apinotes" -o "%VCToolsInstallDir%/include/visualc.apinotes"
-        curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/winsdk.modulemap" -o "%UniversalCRTSdkDir%/Include/%UCRTVersion%/um/module.modulemap"
-      displayName: 'Configure SDK'
-    - task: DownloadBuildArtifacts@0
-      inputs:
-        buildType: specific
-        project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
-        allowPartiallySucceededBuilds: true
-        pipeline: 9
-        artifactName: 'icu-$(platform)-$(host)'
-        downloadPath: '$(Build.StagingDirectory)'
-      displayName: 'Install ICU'
-    - template: templates/toolchain.yml
-    - script: |
-        echo ##vso[task.setvariable variable=PATH]$(icu.directory)/usr/bin;$(install.directory)\bin;$(Build.StagingDirectory)\swift\libdispatch-prefix\bin;%PATH%;%ProgramFiles%\Git\usr\bin
-      displayName: 'Update PATH'
-    - task: CMake@1
-      inputs:
-        cmakeArgs: --build $(Build.StagingDirectory)\toolchain --target check-swift
-      displayName: 'test swift'
-      continueOnError: true
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFormat: 'JUnit'
-        testResultsFiles: '$(Build.StagingDirectory)/toolchain/swift-test-results/*/*.xml'
+      LLVM_OPTIONS: -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+      LLDB_OPTIONS: -DLLDB_DISABLE_PYTHON=YES
+      SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=8 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES

--- a/.ci/toolchain-vs2019-amd64.yml
+++ b/.ci/toolchain-vs2019-amd64.yml
@@ -6,6 +6,25 @@ pr:
     include:
       - .ci/toolchain-vs2019-amd64.yml
       - .ci/templates/toolchain.yml
+resources:
+  repositories:
+    - repository: apple/llvm-project
+      type: github
+      name: apple/llvm-project
+      ref: refs/heads/swift/master
+      endpoint: GitHub
+    - repository: apple/swift-cmark
+      type: github
+      name: apple/swift-cmark
+      endpoint: GitHub
+    - repository: apple/swift-corelibs-libdispatch
+      type: github
+      name: apple/swift-corelibs-libdispatch
+      endpoint: GitHub
+    - repository: apple/swift
+      type: github
+      name: apple/swift
+      endpoint: GitHub
 schedules:
   - cron: "0 0 * * *"
     branches:
@@ -22,15 +41,12 @@ trigger:
       - .ci/toolchain-vs2019-amd64.yml
       - .ci/templates/toolchain.yml
 jobs:
-  - job: windows_x64
-    # NOTE(compnerd) this is an open source project built on hosted machines, so
-    # this time out is actually 6 hours.  Sadly, this is not very long given the
-    # complexity of this build and the speed of the hosted machines
-    timeoutInMinutes: 0
-    pool:
-      vmImage: 'windows-2019'
-    variables:
-      branch: master
+  - template: templates/toolchain.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
+      tests: true
 
       arch: x86_64
       host: x64
@@ -38,58 +54,6 @@ jobs:
 
       triple: x86_64-unknown-windows-msvc
 
-      install.directory: $(Build.StagingDirectory)/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr
-
-      icu.version : 64
-      icu.directory: $(System.ArtifactsDirectory)/icu-$(platform)-$(host)/ICU-$(icu.version)
-
-      llvm.extra_cmake_flags: -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(pythonTools.pythonLocation)/python.exe
-      swift.extra_cmake_flags: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DLLVM_PARALLEL_LINK_JOBS=2 -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES
-      lldb.extra_cmake_flags: -DLLDB_DISABLE_PYTHON=YES
-    steps:
-      - task: BatchScript@1
-        inputs:
-          filename: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
-          arguments: -no_logo -arch=x64 -host_arch=x64
-          modifyEnvironment: true
-        displayName: 'vcvarsall.bat'
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '2.7.x'
-        name: pythonTools
-      - script: python -m pip install --upgrade flake8
-        displayName: 'Install flake8'
-      - script: |
-          echo "##vso[task.setvariable variable=PATH]$(install.directory)/bin;%PATH%"
-        displayName: 'Update PATH'
-      # TODO(compnerd) figure out how to account for patches to these files
-      - script: |
-          curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/ucrt.modulemap" -o "%UniversalCRTSdkDir%/Include/%UCRTVersion%/ucrt/module.modulemap"
-          curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.modulemap" -o "%VCToolsInstallDir%/include/module.modulemap"
-          curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.apinotes" -o "%VCToolsInstallDir%/include/visualc.apinotes"
-          curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/winsdk.modulemap" -o "%UniversalCRTSdkDir%/Include/%UCRTVersion%/um/module.modulemap"
-        displayName: 'Configure SDK'
-      - task: DownloadBuildArtifacts@0
-        inputs:
-          buildType: specific
-          project: '3133d6ab-80a8-4996-ac4f-03df25cd3224'
-          allowPartiallySucceededBuilds: true
-          pipeline: 9
-          artifactName: 'icu-$(platform)-$(host)'
-          downloadPath: '$(Build.StagingDirectory)'
-        displayName: 'Install ICU'
-      - template: templates/toolchain.yml
-      - script: |
-          echo ##vso[task.setvariable variable=PATH]$(icu.directory)/usr/bin;$(install.directory)\bin;$(Build.StagingDirectory)\swift\libdispatch-prefix\bin;%PATH%;%ProgramFiles%\Git\usr\bin
-        displayName: 'Update PATH'
-      - task: CMake@1
-        inputs:
-          cmakeArgs: --build $(Build.StagingDirectory)\toolchain --target check-swift
-        displayName: 'test swift'
-        continueOnError: true
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFormat: 'JUnit'
-          testResultsFiles: '$(Build.StagingDirectory)/toolchain/swift-test-results/*/*.xml'
-          buildPlatform: 'Windows-x86_64'
-          buildConfiguration: 'VS2019'
+      LLVM_OPTIONS: -DLLVM_PARALLEL_LINK_JOBS=2 -DPYTHON_EXECUTABLE=$(python.pythonLocation)/python.exe
+      LLDB_OPTIONS: -DLLDB_DISABLE_PYTHON=YES
+      SWIFT_OPTIONS: -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=$(icu.directory)/usr/include/unicode -DSWIFT_WINDOWS_x86_64_ICU_UC=$(icu.directory)/usr/lib/icuuc$(icu.version).lib -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=$(icu.directory)/usr/include -DSWIFT_WINDOWS_x86_64_ICU_I18N=$(icu.directory)/usr/lib/icuin$(icu.version).lib -DSWIFT_PARALLEL_LINK_JOBS=2 -DSWIFT_BUILD_DYNAMIC_STDLIB=YES -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES

--- a/.ci/toolchain-vs2019-arm64-5.2.yml
+++ b/.ci/toolchain-vs2019-arm64-5.2.yml
@@ -6,6 +6,28 @@ pr:
     include:
       - .ci/toolchain-vs2019-arm64-5.2.yml
       - .ci/templates/toolchain.yml
+resources:
+  repositories:
+    - repository: apple/llvm-project
+      type: github
+      name: apple/llvm-project
+      ref: refs/heads/swift/swift-5.2-branch
+      endpoint: GitHub
+    - repository: apple/swift-cmark
+      type: github
+      name: apple/swift-cmark
+      ref: refs/heads/swift-5.2-branch
+      endpoint: GitHub
+    - repository: apple/swift-corelibs-libdispatch
+      type: github
+      name: apple/swift-corelibs-libdispatch
+      ref: refs/heads/swift-5.2-branch
+      endpoint: GitHub
+    - repository: apple/swift
+      type: github
+      name: apple/swift
+      ref: refs/heads/swift-5.2-branch
+      endpoint: GitHub
 schedules:
   - cron: "0 17 * * *"
     branches:
@@ -21,82 +43,20 @@ trigger:
     include:
       - .ci/toolchain-vs2019-arm64-5.2.yml
       - .ci/templates/toolchain.yml
-variables:
-  Install.Directory: $(Build.StagingDirectory)\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr
 jobs:
-  - job: windows
-    # NOTE(compnerd) this is an open source project built on hosted machines, so
-    # this time out is actually 6 hours.  Sadly, this is not very long given the
-    # complexity of this build and the speed of the hosted machines
-    timeoutInMinutes: 0
-    pool:
-      vmImage: 'windows-2019'
-    steps:
-      - script: |
-          git config --global core.autocrlf false
+  - template: templates/toolchain.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-          git config --global user.name 'builder'
-          git config --global user.email 'builder@compnerd.org'
+      arch: aarch64
+      host: arm64
+      platform: windows
 
-          git clone --quiet --depth 1 --single-branch --branch swift/swift-5.2-branch https://github.com/apple/llvm-project toolchain
+      triple: aarch64-unknown-windows-msvc
 
-          git clone --quiet --depth 1 --single-branch --branch swift-5.2-branch https://github.com/apple/swift-cmark toolchain/cmark
-          git clone --quiet --depth 1 --single-branch --branch swift-5.2-branch https://github.com/apple/swift-corelibs-libdispatch toolchain/swift-corelibs-libdispatch
-          git clone --config core.autocrlf=false --config core.symlinks=true --quiet --depth 1 --single-branch --branch swift-5.2-branch https://github.com/apple/swift toolchain/swift
-        displayName: 'Fetch Sources'
-      - task: BatchScript@1
-        inputs:
-          fileName: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
-          arguments: -no_logo -arch=x64 -host_arch=x64
-          modifyEnvironment: true
-        displayName: 'vcvarsall.bat'
-      - task: CMake@1
-        inputs:
-          workingDirectory: $(Build.StagingDirectory)/llvm-tools
-          cmakeArgs: $(Build.SourcesDirectory)\toolchain\llvm -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DLLVM_ENABLE_ASSERTIONS=NO -DLLVM_ENABLE_PROJECTS="clang;lldb" -DLLDB_DISABLE_PYTHON=YES
-        displayName: 'Configure LLVM Build Tools'
-      - task: CMake@1
-        inputs:
-          cmakeArgs: --build $(Build.StagingDirectory)/llvm-tools --target llvm-tblgen
-        displayName: 'Build LLVM Build Tools'
-      - task: CMake@1
-        inputs:
-          cmakeArgs: --build $(Build.StagingDirectory)/llvm-tools --target clang-tblgen
-        displayName: 'Build Clang Build Tools'
-      - task: CMake@1
-        inputs:
-          cmakeArgs: --build $(Build.StagingDirectory)/llvm-tools --target lldb-tblgen
-        displayName: 'Build LLDB Build Tools'
-      - task: BatchScript@1
-        inputs:
-          filename: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
-          arguments: -no_logo -arch=arm64 -host_arch=x64
-          modifyEnvironment: true
-        displayName: 'vcvarsall.bat'
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '2.7.x'
-      - script: |
-          mklink "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap" "$(Build.SourcesDirectory)\toolchain\swift\stdlib\public\Platform\ucrt.modulemap"
-          mklink "%VCToolsInstallDir%\include\module.modulemap" "$(Build.SourcesDirectory)\toolchain\swift\stdlib\public\Platform\visualc.modulemap"
-          mklink "%VCToolsInstallDir%\include\visualc.apinotes" "$(Build.SourcesDirectory)\toolchain\swift\stdlib\public\Platform\visualc.apinotes"
-          mklink "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap" "$(Build.SourcesDirectory)\toolchain\swift\stdlib\public\Platform\winsdk.modulemap"
-        displayName: 'Configure SDK'
-      - task: CMake@1
-        inputs:
-          workingDirectory: $(Build.StagingDirectory)/toolchain
-          # NOTE(compnerd) DIA does not contain ARM64 diaguids.lib
-          cmakeArgs: -C $(Build.SourcesDirectory)/cmake/caches/Windows-aarch64.cmake -C $(Build.SourcesDirectory)\cmake\caches\org.compnerd.dt.cmake -G Ninja $(Build.SourcesDirectory)\toolchain\llvm -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(Install.Directory) -DLLVM_DEFAULT_TARGET_TRIPLE=aarch64-unknown-windows-msvc -DLLVM_USE_HOST_TOOLS=NO -DLLVM_TABLEGEN=$(Build.StagingDirectory)\llvm-tools\bin\llvm-tblgen.exe -DCLANG_TABLEGEN=$(Build.StagingDirectory)\llvm-tools\bin\clang-tblgen.exe -DLLDB_TABLEGEN=$(Build.StagingDirectory)\llvm-tools\bin\lldb-tblgen.exe -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;cmark;swift;lldb;lld" -DLLVM_EXTERNAL_PROJECTS="cmark;swift" -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE=$(Build.SourcesDirectory)/toolchain/swift-corelibs-libdispatch -DLLVM_ENABLE_ASSERTIONS=YES -DLLVM_ENABLE_DIA_SDK=NO -DLLDB_DISABLE_PYTHON=YES -DSWIFT_INCLUDE_TESTS=NO -DSWIFT_BUILD_SYNTAXPARSERLIB=NO -DSWIFT_BUILD_SOURCEKIT=NO -DSWIFT_ENABLE_SOURCEKIT_TESTS=NO
-        displayName: 'Configure toolchain'
-      - task: CMake@1
-        inputs:
-          cmakeArgs: --build $(Build.StagingDirectory)/toolchain --target distribution
-        displayName: 'Build toolchain'
-      - task: CMake@1
-        inputs:
-          cmakeArgs: --build $(Build.StagingDirectory)/toolchain --target install-distribution-stripped
-        displayName: 'Install toolchain'
-      - task: PublishBuildArtifacts@1
-        inputs:
-          pathtoPublish: $(Build.StagingDirectory)\Library
-          artifactName: toolchain
+      # NOTE(compnerd) DIA does not contain ARM64 diaguids.lib
+      LLVM_OPTIONS: -DLLVM_ENABLE_DIA_SDK=NO -DLLVM_INCLUDE_TESTS=NO -DCLANG_INCLUDE_TESTS=NO -DLLD_INCLUDE_TESTS=NO
+      LLDB_OPTIONS: -DLLDB_DISABLE_PYTHON=YES -DLLDB_INCLUDE_TESTS=NO
+      SWIFT_OPTIONS: -DSWIFT_INCLUDE_TESTS=NO -DSWIFT_ENABLE_SOURCEKIT_TESTS=NO

--- a/.ci/toolchain-vs2019-arm64.yml
+++ b/.ci/toolchain-vs2019-arm64.yml
@@ -1,3 +1,30 @@
+pr:
+  branches:
+    include:
+      - master
+  paths:
+    include:
+      - .ci/toolchain-vs2019-arm64.yml
+      - .ci/templates/toolchain.yml
+resources:
+  repositories:
+    - repository: apple/llvm-project
+      type: github
+      name: apple/llvm-project
+      ref: refs/heads/swift/master
+      endpoint: GitHub
+    - repository: apple/swift-cmark
+      type: github
+      name: apple/swift-cmark
+      endpoint: GitHub
+    - repository: apple/swift-corelibs-libdispatch
+      type: github
+      name: apple/swift-corelibs-libdispatch
+      endpoint: GitHub
+    - repository: apple/swift
+      type: github
+      name: apple/swift
+      endpoint: GitHub
 schedules:
   - cron: "0 0 * * *"
     branches:
@@ -12,82 +39,21 @@ trigger:
   paths:
     include:
       - .ci/toolchain-vs2019-arm64.yml
-variables:
-  Install.Directory: $(Build.StagingDirectory)\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr
+      - .ci/templates/toolchain.yml
 jobs:
-  - job: windows
-    # NOTE(compnerd) this is an open source project built on hosted machines, so
-    # this time out is actually 6 hours.  Sadly, this is not very long given the
-    # complexity of this build and the speed of the hosted machines
-    timeoutInMinutes: 0
-    pool:
-      vmImage: 'windows-2019'
-    steps:
-      - script: |
-          git config --global core.autocrlf false
+  - template: templates/toolchain.yml
+    parameters:
+      VisualStudio: 2019/Enterprise
+      pool:
+        vmImage: 'windows-2019'
 
-          git config --global user.name 'builder'
-          git config --global user.email 'builder@compnerd.org'
+      arch: aarch64
+      host: arm64
+      platform: windows
 
-          git clone --quiet --depth 1 --single-branch --branch swift/master https://github.com/apple/llvm-project toolchain
+      triple: aarch64-unknown-windows-msvc
 
-          git clone --quiet --depth 1 --single-branch https://github.com/apple/swift-cmark toolchain/cmark
-          git clone --quiet --depth 1 --single-branch https://github.com/apple/swift-corelibs-libdispatch toolchain/swift-corelibs-libdispatch
-          git clone --config core.autocrlf=false --config core.symlinks=true --quiet --depth 1 --single-branch https://github.com/apple/swift toolchain/swift
-        displayName: 'Fetch Sources'
-      - task: BatchScript@1
-        inputs:
-          fileName: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
-          arguments: -no_logo -arch=x64 -host_arch=x64
-          modifyEnvironment: true
-        displayName: 'vcvarsall.bat'
-      - task: CMake@1
-        inputs:
-          workingDirectory: $(Build.StagingDirectory)/llvm-tools
-          cmakeArgs: $(Build.SourcesDirectory)\toolchain\llvm -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DLLVM_ENABLE_ASSERTIONS=NO -DLLVM_ENABLE_PROJECTS="clang;lldb" -DLLDB_DISABLE_PYTHON=YES
-        displayName: 'Configure LLVM Build Tools'
-      - task: CMake@1
-        inputs:
-          cmakeArgs: --build $(Build.StagingDirectory)/llvm-tools --target llvm-tblgen
-        displayName: 'Build LLVM Build Tools'
-      - task: CMake@1
-        inputs:
-          cmakeArgs: --build $(Build.StagingDirectory)/llvm-tools --target clang-tblgen
-        displayName: 'Build Clang Build Tools'
-      - task: CMake@1
-        inputs:
-          cmakeArgs: --build $(Build.StagingDirectory)/llvm-tools --target lldb-tblgen
-        displayName: 'Build LLDB Build Tools'
-      - task: BatchScript@1
-        inputs:
-          filename: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
-          arguments: -no_logo -arch=arm64 -host_arch=x64
-          modifyEnvironment: true
-        displayName: 'vcvarsall.bat'
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '2.7.x'
-      - script: |
-          mklink "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap" "$(Build.SourcesDirectory)\toolchain\swift\stdlib\public\Platform\ucrt.modulemap"
-          mklink "%VCToolsInstallDir%\include\module.modulemap" "$(Build.SourcesDirectory)\toolchain\swift\stdlib\public\Platform\visualc.modulemap"
-          mklink "%VCToolsInstallDir%\include\visualc.apinotes" "$(Build.SourcesDirectory)\toolchain\swift\stdlib\public\Platform\visualc.apinotes"
-          mklink "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap" "$(Build.SourcesDirectory)\toolchain\swift\stdlib\public\Platform\winsdk.modulemap"
-        displayName: 'Configure SDK'
-      - task: CMake@1
-        inputs:
-          workingDirectory: $(Build.StagingDirectory)/toolchain
-          # NOTE(compnerd) DIA does not contain ARM64 diaguids.lib
-          cmakeArgs: -C $(Build.SourcesDirectory)/cmake/caches/Windows-aarch64.cmake -C $(Build.SourcesDirectory)\cmake\caches\org.compnerd.dt.cmake -G Ninja $(Build.SourcesDirectory)\toolchain\llvm -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(Install.Directory) -DLLVM_DEFAULT_TARGET_TRIPLE=aarch64-unknown-windows-msvc -DLLVM_USE_HOST_TOOLS=NO -DLLVM_TABLEGEN=$(Build.StagingDirectory)\llvm-tools\bin\llvm-tblgen.exe -DCLANG_TABLEGEN=$(Build.StagingDirectory)\llvm-tools\bin\clang-tblgen.exe -DLLDB_TABLEGEN=$(Build.StagingDirectory)\llvm-tools\bin\lldb-tblgen.exe -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;cmark;swift;lldb;lld" -DLLVM_EXTERNAL_PROJECTS="cmark;swift" -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE=$(Build.SourcesDirectory)/toolchain/swift-corelibs-libdispatch -DLLVM_ENABLE_ASSERTIONS=YES -DLLVM_ENABLE_DIA_SDK=NO -DLLDB_DISABLE_PYTHON=YES -DSWIFT_INCLUDE_TESTS=NO -DSWIFT_BUILD_SYNTAXPARSERLIB=NO -DSWIFT_BUILD_SOURCEKIT=NO -DSWIFT_ENABLE_SOURCEKIT_TESTS=NO
-        displayName: 'Configure toolchain'
-      - task: CMake@1
-        inputs:
-          cmakeArgs: --build $(Build.StagingDirectory)/toolchain --target distribution
-        displayName: 'Build toolchain'
-      - task: CMake@1
-        inputs:
-          cmakeArgs: --build $(Build.StagingDirectory)/toolchain --target install-distribution-stripped
-        displayName: 'Install toolchain'
-      - task: PublishBuildArtifacts@1
-        inputs:
-          pathtoPublish: $(Build.StagingDirectory)\Library
-          artifactName: toolchain
+      # NOTE(compnerd) DIA does not contain ARM64 diaguids.lib
+      LLVM_OPTIONS: -DLLVM_ENABLE_DIA_SDK=NO -DLLVM_INCLUDE_TESTS=NO -DCLANG_INCLUDE_TESTS=NO -DLLD_INCLUDE_TESTS=NO
+      LLDB_OPTIONS: -DLLDB_DISABLE_PYTHON=YES -DLLDB_INCLUDE_TESTS=NO
+      SWIFT_OPTIONS: -DSWIFT_INCLUDE_TESTS=NO -DSWIFT_ENABLE_SOURCEKIT_TESTS=NO


### PR DESCRIPTION
This begins the homogenisation of the toolchain builds.  By pushing all
the builds into a template, it becomes more feasible to make the
toolchain job a job template.  At that point, it will become possible to
synchronise the VS2017, VS2019 builds across development and stable,
reducing the pipelines.  This also migrates the builds to
multi-repository checkouts, full checkouts, and pipeline artifacts.  The
fallout of this will ripple through the rest of the builds, but, will
enable better build strategies.