### PR TITLE
[FB] Spread out builds. Move Build Completion trigger to YAML.

### DIFF
--- a/.ci/toolchain-vs2017-amd64-facebook.yml
+++ b/.ci/toolchain-vs2017-amd64-facebook.yml
@@ -34,14 +34,8 @@ resources:
       name: apple/swift
       endpoint: GitHub
 schedules:
-- cron: "0 */3 * * *"
-  displayName: "O'clock builds"
-  branches:
-    include:
-    - master
-  always: true
-- cron: "30 1-22/3 * * *"
-  displayName: "Half past builds"
+- cron: "0 */2 * * *"
+  displayName: "Toolchain builds"
   branches:
     include:
     - master

--- a/.ci/toolchain-vs2019-amd64-facebook.yml
+++ b/.ci/toolchain-vs2019-amd64-facebook.yml
@@ -26,14 +26,8 @@ resources:
       name: apple/swift
       endpoint: GitHub
 schedules:
-- cron: "0 */3 * * *"
-  displayName: "O'clock builds"
-  branches:
-    include:
-    - master
-  always: true
-- cron: "30 1-22/3 * * *"
-  displayName: "Half past builds"
+- cron: "0 */2 * * *"
+  displayName: "Toolchain builds"
   branches:
     include:
     - master

--- a/.ci/windows-sdk-facebook-vs2017.yml
+++ b/.ci/windows-sdk-facebook-vs2017.yml
@@ -14,6 +14,14 @@ trigger:
     include:
       - .ci/windows-sdk-facebook-vs2017.yml
       - .ci/templates/windows-sdk.yml
+resources:
+  pipelines:
+  - pipeline: toolchain
+    source: 'Development\Facebook\VS2017/Toolchain for Windows x64'
+    trigger:
+      branches:
+        include:
+        - master
 jobs:
   - template: templates/windows-sdk.yml
     parameters:
@@ -58,4 +66,3 @@ jobs:
       arch: 'i686'
       host: 'x86'
       triple: 'i686-unknown-windows-msvc'
-

--- a/.ci/windows-sdk-facebook-vs2019.yml
+++ b/.ci/windows-sdk-facebook-vs2019.yml
@@ -14,6 +14,14 @@ trigger:
     include:
       - .ci/windows-sdk-facebook-vs2019.yml
       - .ci/templates/windows-sdk.yml
+resources:
+  pipelines:
+  - pipeline: toolchain
+    source: 'Development\Facebook\VS2019/Toolchain for Windows x64'
+    trigger:
+      branches:
+        include:
+        - master
 jobs:
   - template: templates/windows-sdk.yml
     parameters:
@@ -58,4 +66,3 @@ jobs:
       arch: 'i686'
       host: 'x86'
       triple: 'i686-unknown-windows-msvc'
-


### PR DESCRIPTION
Since there's only one machine in the pools for VS2017 and VS2019, builds every 1h30min were a little bit too much for the machine, since the SDK was also build in the same machine and both of them take around 2 hours, so the builds were starting to queue up.

Move the toolchain builds around 2 hours apart, which should avoid the queueing. Also move the Build Completion triggers to YAML to have them under source control management.